### PR TITLE
Add ScopedLoggerProvider to share scope between loggers

### DIFF
--- a/core/src/Juice.Extensions.Logging/LoggerProvider.cs
+++ b/core/src/Juice.Extensions.Logging/LoggerProvider.cs
@@ -4,34 +4,17 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Juice.Extensions.Logging
 {
-    public abstract class LoggerProvider : IDisposable, ILoggerProvider, ISupportExternalScope
+    public abstract class LoggerProvider : IDisposable, ILoggerProvider
     {
         private ConcurrentDictionary<string, Logger> _loggers
             = new(StringComparer.OrdinalIgnoreCase);
         public ILogger CreateLogger(string categoryName)
             => _loggers.GetOrAdd(categoryName, name => new Logger(this, categoryName));
 
-
-        IExternalScopeProvider _scopeProvider;
-        public void SetScopeProvider(IExternalScopeProvider scopeProvider)
-        {
-            _scopeProvider = scopeProvider;
-        }
-        public IExternalScopeProvider ScopeProvider
-        {
-            get
-            {
-                if (_scopeProvider == null)
-                    _scopeProvider = new LoggerExternalScopeProvider();
-                return _scopeProvider;
-            }
-        }
-
         /// <summary>
         /// Writes the specified log information to a log file.
         /// </summary>
-        public abstract void WriteLog<TState>(LogEntry<TState> entry, string formattedMessage);
-
+        public abstract void WriteLog<TState>(LogEntry<TState> entry, string formattedMessage, IExternalScopeProvider? scopeProvider);
 
         #region IDisposable Support
 
@@ -65,4 +48,25 @@ namespace Juice.Extensions.Logging
 
         #endregion
     }
+
+    public abstract class ScopedLoggerProvider : LoggerProvider, ISupportExternalScope
+    {
+
+        private IExternalScopeProvider? _scopeProvider;
+        /// <inheritdoc/>
+        public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+        {
+            _scopeProvider = scopeProvider;
+        }
+        public IExternalScopeProvider ScopeProvider
+        {
+            get
+            {
+                if (_scopeProvider == null)
+                    _scopeProvider = new LoggerExternalScopeProvider();
+                return _scopeProvider;
+            }
+        }
+    }
+
 }

--- a/core/test/Juice.Core.Tests/Juice.Core.Tests.csproj
+++ b/core/test/Juice.Core.Tests/Juice.Core.Tests.csproj
@@ -18,6 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+      <PackageReference Include="FluentAssertions" Version="6.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/core/test/Juice.Core.Tests/LoggerProviderTest.cs
+++ b/core/test/Juice.Core.Tests/LoggerProviderTest.cs
@@ -1,7 +1,16 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Juice.Extensions.DependencyInjection;
+using Juice.Extensions.Logging;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -37,6 +46,85 @@ namespace Juice.Core.Tests
                 logger.LogInformation("Log ok");
                 logger.LogWarning("Log ok");
             }
+        }
+
+
+        [Fact(DisplayName = "Scopes should by logger")]
+        public async Task LogScope_should_by_loggerAsync()
+        {
+            var resolver = new DependencyResolver
+            {
+                CurrentDirectory = AppContext.BaseDirectory
+            };
+            var stringBuilder = new StringBuilder();
+            resolver.ConfigureServices(services =>
+            {
+                var configService = services.BuildServiceProvider().GetRequiredService<IConfigurationService>();
+                var configuration = configService.GetConfiguration();
+                services.AddSingleton(provider => _output);
+                services.AddLogging(builder =>
+                {
+                    builder.ClearProviders()
+                   .AddProvider(new TestOutputLoggerProvider(_output))
+                   .AddProvider(new StringBuilderLoggerProvider(stringBuilder))
+                   .AddConfiguration(configuration.GetSection("Logging"));
+                });
+            });
+
+            var factory = resolver.ServiceProvider.GetRequiredService<ILoggerFactory>();
+            var logger1 = factory.CreateLogger("Logger1");
+            var logger2 = factory.CreateLogger("Logger2");
+
+            using (logger1.BeginScope("Scope1"))
+            {
+                logger1.LogInformation("Log1");
+                var scope = stringBuilder.ToString().Trim();
+                stringBuilder.Clear();
+                _output.WriteLine(scope);
+                scope.Should().StartWith(JsonConvert.SerializeObject(new string[] { "Scope1" }));
+
+                logger2.LogInformation("Log2");
+                scope = stringBuilder.ToString().Trim();
+                stringBuilder.Clear();
+                _output.WriteLine(scope);
+                scope.Should().Be("Log2");
+
+                using (logger2.BeginScope("Scope2"))
+                {
+                    logger1.LogInformation("Log1");
+                    scope = stringBuilder.ToString().Trim();
+                    stringBuilder.Clear();
+                    _output.WriteLine(scope);
+                    scope.Should().StartWith(JsonConvert.SerializeObject(new string[] { "Scope1" }));
+
+                    logger2.LogInformation("Log2");
+                    scope = stringBuilder.ToString().Trim();
+                    stringBuilder.Clear();
+                    _output.WriteLine(scope);
+                    scope.Should().StartWith(JsonConvert.SerializeObject(new string[] { "Scope2" }));
+                }
+            }
+        }
+    }
+
+    internal class StringBuilderLoggerProvider : LoggerProvider
+    {
+        private readonly StringBuilder? _builder;
+        public StringBuilderLoggerProvider(StringBuilder stringBuilder)
+        {
+            _builder = stringBuilder;
+        }
+
+        public override void WriteLog<TState>(LogEntry<TState> entry, string formattedMessage, IExternalScopeProvider? scopeProvider)
+        {
+            var scopes = new List<object?>();
+            scopeProvider?.ForEachScope((value, loggingProps) =>
+            {
+                scopes.Add(value);
+            },
+            entry.State);
+            var scope = scopes.Any() ? JsonConvert.SerializeObject(scopes) : "";
+            _builder?.Append(scope).Append(" ").Append(formattedMessage);
         }
     }
 }

--- a/test/Juice.XUnit/TestOutputLogger.cs
+++ b/test/Juice.XUnit/TestOutputLogger.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.Logging
     {
     }
 
-    public sealed class TestOutputLoggerProvider : LoggerProvider
+    public sealed class TestOutputLoggerProvider : ScopedLoggerProvider
     {
         private readonly ITestOutputHelper _output;
         public TestOutputLoggerProvider(
@@ -21,10 +21,10 @@ namespace Microsoft.Extensions.Logging
             _output = testOutput;
         }
 
-        public override void WriteLog<TState>(LogEntry<TState> entry, string formattedMessage)
+        public override void WriteLog<TState>(LogEntry<TState> entry, string formattedMessage, IExternalScopeProvider? scopeProvider)
         {
             var scopes = new List<object?>();
-            ScopeProvider.ForEachScope((value, loggingProps) =>
+            ScopeProvider?.ForEachScope((value, loggingProps) =>
             {
                 scopes.Add(value);
             },


### PR DESCRIPTION
The abstract class LoggerProvider should no longer inherit the interface ISupportExternalScope but use the ScopedLoggerProvider instead