### PR TITLE
feat: make IMessageService transaction-aware with post-commit local d…

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     <PackageIconUrl>https://avatars.githubusercontent.com/u/107674950</PackageIconUrl>
     <RepositoryUrl>https://github.com/creatorflow-io/Juice</RepositoryUrl>
 
-    <VersionPrefix>9.3.0</VersionPrefix>
+    <VersionPrefix>9.3.1</VersionPrefix>
     <VersionSuffix>local.$([System.DateTime]::Now.ToString(`yyyyMMdd`)).1</VersionSuffix>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/core/src/Juice.MediatR.Behaviors/TransactionBehavior.cs
+++ b/core/src/Juice.MediatR.Behaviors/TransactionBehavior.cs
@@ -106,6 +106,7 @@ namespace Juice.MediatR.Behaviors
         private readonly TContext _dbContext;
         private readonly IOutboxService _outboxService;
         private readonly IMediator _mediator;
+        private readonly IPostCommitActions? _postCommitActions;
         /// <summary>
         /// Gets a value indicating whether integration events should be published after processing.
         /// </summary>
@@ -116,12 +117,14 @@ namespace Juice.MediatR.Behaviors
         public TransactionBehavior(TContext dbContext,
             IOutboxService<TContext> integrationEventService,
             IMediator mediator,
-            ILogger logger)
+            ILogger logger,
+            IPostCommitActions? postCommitActions = null)
         {
             _dbContext = dbContext ?? throw new ArgumentException(typeof(TContext).Name);
             _outboxService = integrationEventService ?? throw new ArgumentException(nameof(integrationEventService));
             _mediator = mediator ?? throw new ArgumentException(nameof(IMediator));
             _logger = logger ?? throw new ArgumentException(nameof(ILogger));
+            _postCommitActions = postCommitActions;
         }
 
         public async ValueTask<TResponse> Handle(TRequest request, RequestHandlerDelegate<TRequest, TResponse> next, CancellationToken cancellationToken)
@@ -174,6 +177,11 @@ namespace Juice.MediatR.Behaviors
                         _logger.LogDebug("----- Transaction {TransactionId} committed", transaction.TransactionId);
                     }
                     _dbContext.ClearEvents();
+
+                    // Flush deferred local dispatch actions (e.g., channel enqueue
+                    // for "local" routes). These were registered by IMessageService
+                    // during domain event dispatch and deferred until after commit.
+                    _postCommitActions?.Flush();
                 }, cancellationToken);
 
                 return response;

--- a/core/src/Juice.Messaging.Local/Internal/MessageServiceT.cs
+++ b/core/src/Juice.Messaging.Local/Internal/MessageServiceT.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Channels;
+using Juice.Domain;
 using Juice.Messaging.Integrations;
 using Juice.Messaging.Outbox;
 using Juice.MultiTenant;
@@ -19,40 +20,57 @@ namespace Juice.Messaging.Local.Internal
     /// For broker routes the message is written to the outbox only.
     /// </para>
     /// <para>
-    /// When called inside an active <c>TransactionBehavior</c> scope,
-    /// <c>SaveEventsAsync</c> joins the ambient transaction; the behavior's final
-    /// <c>SaveEventsAsync</c> call finds no pending messages (cleared after first save)
-    /// and becomes a no-op.
+    /// <c>"local-channel"</c> and <c>"local"</c> are mutually exclusive — if the policy
+    /// resolves both, <c>"local"</c> takes precedence (durable superset) and the
+    /// <c>"local-channel"</c> route is ignored to prevent double handler invocation.
+    /// </para>
+    /// <para>
+    /// When called inside a managed <c>TransactionBehavior</c> scope (detected via
+    /// <c>IUnitOfWork.IsManaged</c>), only <c>AddEventAsync</c> is called — the save
+    /// is deferred to <c>TransactionBehavior</c>'s <c>SaveEventsAsync(transactionId)</c>,
+    /// ensuring atomicity with domain data. Immediate channel dispatch for <c>"local"</c>
+    /// routes is also suppressed (data not yet committed).
+    /// </para>
+    /// <para>
+    /// When called outside a managed transaction, <c>SaveEventsAsync(null)</c> is called
+    /// immediately as a standalone operation, and <c>"local"</c> routes are enqueued to
+    /// the channel for immediate dispatch.
     /// </para>
     /// </summary>
     internal sealed class MessageService<TContext> : MessageService, IMessageService<TContext>
         where TContext : class
     {
         private readonly IOutboxService<TContext>? _outboxService;
+        private readonly TContext? _context;
+        private readonly IPostCommitActions? _postCommitActions;
 
         public MessageService(
             Policies.IMessagePublishingPolicy policy,
             ChannelWriter<IMessage> channelWriter,
             ILogger<MessageService<TContext>> logger,
             IOutboxService<TContext>? outboxService = null,
+            TContext? context = null,
+            IPostCommitActions? postCommitActions = null,
             ITenantAccessor? tenantAccessor = null)
             : base(policy, channelWriter, logger, tenantAccessor)
         {
             _outboxService = outboxService;
+            _context = context;
+            _postCommitActions = postCommitActions;
         }
 
         public override async Task PublishAsync(IMessage message, CancellationToken cancellationToken = default)
         {
             var routes = await ResolveRoutesAsync(message);
 
-            bool hasLocalChannel = false;
             bool hasLocalOutbox = false;
             bool hasOutboxRoutes = false;
+            bool hasLocalChannelOnly = false;
 
             foreach (var route in routes)
             {
                 if (route.PublisherKey == "local-channel")
-                    hasLocalChannel = true;
+                    hasLocalChannelOnly = true;
                 else
                 {
                     hasOutboxRoutes = true;
@@ -61,7 +79,13 @@ namespace Juice.Messaging.Local.Internal
                 }
             }
 
-            if (hasLocalChannel)
+            // "local" supersedes "local-channel" — they are mutually exclusive.
+            // If both are present, "local" wins (durable superset) to prevent
+            // double handler invocation.
+            if (hasLocalOutbox)
+                hasLocalChannelOnly = false;
+
+            if (hasLocalChannelOnly)
             {
                 EnqueueLocalChannel(message);
             }
@@ -79,16 +103,31 @@ namespace Juice.Messaging.Local.Internal
                     throw new InvalidOperationException("MessageContext is not initialized. An ambient MessageContext scope is required to publish messages with outbox routes.");
                 }
                 await _outboxService.AddEventAsync(message);
-                // OutboxEventService resolves routes internally and skips "local-channel".
-                // Passing transactionId=null: when inside an ambient transaction the
-                // OutboxRepository joins it; when outside, a standalone write is committed.
+
+                var isManaged = _context is IUnitOfWork { IsManaged: true };
+
+                if (isManaged)
+                {
+                    // Inside a managed TransactionBehavior scope — defer save.
+                    // TransactionBehavior will call SaveEventsAsync(transactionId) later,
+                    // persisting all accumulated events atomically with domain data.
+                    // Register a post-commit action to enqueue to channel after commit
+                    // for immediate local dispatch.
+                    if (hasLocalOutbox && _postCommitActions != null)
+                    {
+                        _postCommitActions.Add(() => EnqueueLocalChannel(message));
+                    }
+                    return;
+                }
+
+                // Outside transaction — save immediately as standalone operation.
                 await _outboxService.SaveEventsAsync(null, cancellationToken);
 
                 // For "local" routes, enqueue to the in-memory channel for immediate
                 // best-effort dispatch. The outbox entry remains for durability —
                 // DeliveryHostedService will pick it up on retry if this dispatch fails.
                 // IntegrationEventDispatcher idempotency deduplicates if both succeed.
-                if (hasLocalOutbox && !hasLocalChannel)
+                if (hasLocalOutbox)
                 {
                     EnqueueLocalChannel(message);
                 }

--- a/core/src/Juice.Messaging.Local/Juice.Messaging.Local.csproj
+++ b/core/src/Juice.Messaging.Local/Juice.Messaging.Local.csproj
@@ -14,6 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\Juice\Juice.csproj" />
         <ProjectReference Include="..\Juice.EventBus\Juice.EventBus.csproj" />
         <ProjectReference Include="..\Juice.MediatR\Juice.MediatR.csproj" />
         <ProjectReference Include="..\Juice.Messaging\Juice.Messaging.csproj" />

--- a/core/src/Juice.Messaging/DependencyInjection/MessagingServiceCollectionExtensions.cs
+++ b/core/src/Juice.Messaging/DependencyInjection/MessagingServiceCollectionExtensions.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
             builder.AddIntegrationEventDispatcher();
 
+            services.TryAddScoped<IPostCommitActions, PostCommitActions>();
+
             return builder;
         }
 

--- a/core/src/Juice.Messaging/Outbox/IPostCommitActions.cs
+++ b/core/src/Juice.Messaging/Outbox/IPostCommitActions.cs
@@ -1,0 +1,38 @@
+namespace Juice.Messaging.Outbox
+{
+    /// <summary>
+    /// Scoped service that accumulates actions to execute after a managed transaction
+    /// commits successfully. Used by <c>IMessageService&lt;TContext&gt;</c> to defer
+    /// in-memory channel dispatch until after <c>TransactionBehavior</c> commits,
+    /// enabling immediate local delivery without breaking transactional atomicity.
+    /// </summary>
+    public interface IPostCommitActions
+    {
+        /// <summary>
+        /// Registers an action to execute after the transaction commits.
+        /// </summary>
+        void Add(Action action);
+
+        /// <summary>
+        /// Executes and clears all registered actions. Called by
+        /// <c>TransactionBehavior</c> after <c>CommitTransactionAsync</c>.
+        /// </summary>
+        void Flush();
+    }
+
+    internal sealed class PostCommitActions : IPostCommitActions
+    {
+        private readonly List<Action> _actions = [];
+
+        public void Add(Action action) => _actions.Add(action);
+
+        public void Flush()
+        {
+            foreach (var action in _actions)
+            {
+                action();
+            }
+            _actions.Clear();
+        }
+    }
+}

--- a/core/test/Juice.Messaging.Local.Tests/TransactionAwareTests.cs
+++ b/core/test/Juice.Messaging.Local.Tests/TransactionAwareTests.cs
@@ -1,0 +1,353 @@
+using System.Threading.Channels;
+using FluentAssertions;
+using Juice.Domain;
+using Juice.Messaging;
+using Juice.Messaging.Local;
+using Juice.Messaging.Outbox;
+using Juice.Messaging.Policies;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Juice.XUnit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace Juice.Messaging.Local.Tests
+{
+    /// <summary>
+    /// Tests for transaction-aware behavior of <c>IMessageService&lt;TContext&gt;</c>.
+    /// Verifies that <c>PublishAsync</c> defers outbox save when inside a managed
+    /// <c>TransactionBehavior</c> scope, and saves immediately when outside.
+    /// </summary>
+    public class TransactionAwareTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public TransactionAwareTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        private IServiceProvider BuildServices(
+            string publisherKey,
+            IUnitOfWork? unitOfWork = null,
+            Action<IServiceCollection>? configure = null)
+        {
+            var services = new ServiceCollection();
+            services.AddLogging(b => b.AddTestOutputLogger(_output));
+
+            var messaging = services.AddMessaging();
+            messaging.AddLocalChannel();
+            messaging.AddIdempotencyInMemory();
+
+            services.AddSingleton<IMessagePublishingPolicy>(
+                new FixedRoutePolicy(publisherKey, string.Empty));
+
+            services.AddMediatR();
+
+            // Register a tracking outbox service to verify AddEventAsync / SaveEventsAsync calls
+            var tracker = new OutboxTracker();
+            services.AddSingleton(tracker);
+            services.AddScoped<IOutboxService<FakeDbContext>>(sp =>
+                new TrackingOutboxService(sp.GetRequiredService<OutboxTracker>()));
+
+            // Register the fake context (with or without IUnitOfWork)
+            if (unitOfWork != null)
+            {
+                services.AddScoped<FakeDbContext>(_ => new ManagedFakeDbContext(unitOfWork));
+            }
+            else
+            {
+                services.AddScoped<FakeDbContext>();
+            }
+
+            // Register IMessageService<FakeDbContext>
+            messaging.AddMessageService<FakeDbContext>();
+
+            configure?.Invoke(services);
+            return services.BuildServiceProvider();
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // US1: Inside managed transaction — defer save
+        // ─────────────────────────────────────────────────────────────────────
+
+        [IgnoreOnCIFact]
+        [InitializeMessageContext]
+        public async Task PublishAsync_InsideManagedTransaction_DefersToTransactionBehaviorAsync()
+        {
+            var uow = new FakeUnitOfWork { IsManaged = true };
+            var provider = BuildServices("local", uow);
+
+            var scope = provider.CreateScope();
+            var svc = scope.ServiceProvider.GetRequiredService<IMessageService<FakeDbContext>>();
+            var tracker = provider.GetRequiredService<OutboxTracker>();
+
+            await svc.PublishAsync(new TestIntegrationEvent());
+
+            tracker.AddEventCalled.Should().BeTrue("AddEventAsync should be called to stage the event");
+            tracker.SaveEventsCalled.Should().BeFalse("SaveEventsAsync should NOT be called — deferred to TransactionBehavior");
+        }
+
+        [IgnoreOnCIFact]
+        [InitializeMessageContext]
+        public async Task PublishAsync_InsideManagedTransaction_DefersChannelEnqueueToPostCommitAsync()
+        {
+            var uow = new FakeUnitOfWork { IsManaged = true };
+            var provider = BuildServices("local", uow);
+
+            var scope = provider.CreateScope();
+            var svc = scope.ServiceProvider.GetRequiredService<IMessageService<FakeDbContext>>();
+            var channel = provider.GetRequiredService<ChannelReader<IMessage>>();
+            var postCommit = scope.ServiceProvider.GetRequiredService<IPostCommitActions>();
+
+            await svc.PublishAsync(new TestIntegrationEvent());
+
+            // Before flush — not enqueued yet (data not committed)
+            channel.TryRead(out _).Should().BeFalse(
+                "local route should NOT enqueue to channel before post-commit flush");
+
+            // Simulate TransactionBehavior calling Flush() after commit
+            postCommit.Flush();
+
+            // After flush — enqueued for immediate dispatch
+            channel.TryRead(out _).Should().BeTrue(
+                "local route should be enqueued to channel after post-commit flush");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // US2: Outside transaction — save immediately
+        // ─────────────────────────────────────────────────────────────────────
+
+        [IgnoreOnCIFact]
+        [InitializeMessageContext]
+        public async Task PublishAsync_OutsideTransaction_SavesImmediatelyAsync()
+        {
+            var uow = new FakeUnitOfWork { IsManaged = false };
+            var provider = BuildServices("local", uow);
+
+            var scope = provider.CreateScope();
+            var svc = scope.ServiceProvider.GetRequiredService<IMessageService<FakeDbContext>>();
+            var tracker = provider.GetRequiredService<OutboxTracker>();
+
+            await svc.PublishAsync(new TestIntegrationEvent());
+
+            tracker.AddEventCalled.Should().BeTrue("AddEventAsync should be called");
+            tracker.SaveEventsCalled.Should().BeTrue("SaveEventsAsync should be called immediately outside transaction");
+        }
+
+        [IgnoreOnCIFact]
+        [InitializeMessageContext]
+        public async Task PublishAsync_OutsideTransaction_EnqueuesLocalChannelAsync()
+        {
+            var uow = new FakeUnitOfWork { IsManaged = false };
+            var provider = BuildServices("local", uow);
+
+            var scope = provider.CreateScope();
+            var svc = scope.ServiceProvider.GetRequiredService<IMessageService<FakeDbContext>>();
+            var channel = provider.GetRequiredService<ChannelReader<IMessage>>();
+
+            await svc.PublishAsync(new TestIntegrationEvent());
+
+            channel.TryRead(out _).Should().BeTrue(
+                "local route should enqueue to channel outside transaction for immediate dispatch");
+        }
+
+        [IgnoreOnCIFact]
+        [InitializeMessageContext]
+        public async Task PublishAsync_NullContext_SavesImmediatelyAsync()
+        {
+            // Build without registering FakeDbContext — _context will be null
+            var services = new ServiceCollection();
+            services.AddLogging(b => b.AddTestOutputLogger(_output));
+
+            var messaging = services.AddMessaging();
+            messaging.AddLocalChannel();
+            messaging.AddIdempotencyInMemory();
+
+            services.AddSingleton<IMessagePublishingPolicy>(
+                new FixedRoutePolicy("local", string.Empty));
+            services.AddMediatR();
+
+            var tracker = new OutboxTracker();
+            services.AddSingleton(tracker);
+            services.AddScoped<IOutboxService<FakeDbContext>>(sp =>
+                new TrackingOutboxService(sp.GetRequiredService<OutboxTracker>()));
+
+            // Do NOT register FakeDbContext — so _context is null
+            messaging.AddMessageService<FakeDbContext>();
+
+            var provider = services.BuildServiceProvider();
+            var scope = provider.CreateScope();
+            var svc = scope.ServiceProvider.GetRequiredService<IMessageService<FakeDbContext>>();
+
+            await svc.PublishAsync(new TestIntegrationEvent());
+
+            tracker.SaveEventsCalled.Should().BeTrue(
+                "null context should fall back to immediate save (defensive)");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // US3: Local-channel unaffected by transaction state
+        // ─────────────────────────────────────────────────────────────────────
+
+        [IgnoreOnCIFact]
+        [InitializeMessageContext]
+        public async Task PublishAsync_LocalChannel_InsideTransaction_EnqueuesImmediatelyAsync()
+        {
+            var uow = new FakeUnitOfWork { IsManaged = true };
+            var provider = BuildServices("local-channel", uow);
+
+            var scope = provider.CreateScope();
+            var svc = scope.ServiceProvider.GetRequiredService<IMessageService<FakeDbContext>>();
+            var channel = provider.GetRequiredService<ChannelReader<IMessage>>();
+
+            await svc.PublishAsync(new TestIntegrationEvent());
+
+            channel.TryRead(out _).Should().BeTrue(
+                "local-channel route should enqueue immediately regardless of transaction state");
+        }
+
+        [IgnoreOnCIFact]
+        [InitializeMessageContext]
+        public async Task PublishAsync_DualRoute_InsideTransaction_LocalWinsOverLocalChannelAsync()
+        {
+            var uow = new FakeUnitOfWork { IsManaged = true };
+
+            var services = new ServiceCollection();
+            services.AddLogging(b => b.AddTestOutputLogger(_output));
+
+            var messaging = services.AddMessaging();
+            messaging.AddLocalChannel();
+            messaging.AddIdempotencyInMemory();
+
+            // Policy returns both "local-channel" and "local" routes
+            services.AddSingleton<IMessagePublishingPolicy>(
+                new DualRoutePolicy());
+
+            services.AddMediatR();
+
+            var tracker = new OutboxTracker();
+            services.AddSingleton(tracker);
+            services.AddScoped<IOutboxService<FakeDbContext>>(sp =>
+                new TrackingOutboxService(sp.GetRequiredService<OutboxTracker>()));
+            services.AddScoped<FakeDbContext>(_ => new ManagedFakeDbContext(uow));
+            messaging.AddMessageService<FakeDbContext>();
+
+            var provider = services.BuildServiceProvider();
+            var scope = provider.CreateScope();
+            var svc = scope.ServiceProvider.GetRequiredService<IMessageService<FakeDbContext>>();
+            var channel = provider.GetRequiredService<ChannelReader<IMessage>>();
+
+            var postCommit = scope.ServiceProvider.GetRequiredService<IPostCommitActions>();
+
+            await svc.PublishAsync(new TestIntegrationEvent());
+
+            // "local" supersedes "local-channel" — no channel enqueue before commit
+            channel.TryRead(out _).Should().BeFalse(
+                "local-channel should be suppressed when local route is present — local wins as durable superset");
+
+            // local portion: staged but NOT saved (deferred inside managed tx)
+            tracker.AddEventCalled.Should().BeTrue("outbox event should be staged");
+            tracker.SaveEventsCalled.Should().BeFalse("outbox save should be deferred inside transaction");
+
+            // After post-commit flush — local route enqueues to channel
+            postCommit.Flush();
+            channel.TryRead(out _).Should().BeTrue(
+                "local route should be enqueued to channel after post-commit flush");
+        }
+
+        // ─── Supporting types ────────────────────────────────────────────────
+
+        private sealed record TestIntegrationEvent : IntegrationEvent;
+
+        private class FakeDbContext { }
+
+        private sealed class ManagedFakeDbContext : FakeDbContext, IUnitOfWork
+        {
+            private readonly bool _isManaged;
+            public ManagedFakeDbContext(IUnitOfWork uow) => _isManaged = uow.IsManaged;
+            public bool IsManaged => _isManaged;
+            public bool HasActiveTransaction => false;
+            public void BeginManage() { }
+            public Task<bool> CommitTransactionAsync(Guid transactionId, CancellationToken token = default)
+                => Task.FromResult(true);
+            public Task<int> SaveChangesAsync(CancellationToken token = default) => Task.FromResult(0);
+            public Task AddAsync<T>(T entity, CancellationToken token = default) where T : class
+                => Task.CompletedTask;
+            public Task AddRangeAsync<T>(IEnumerable<T> entities, CancellationToken token = default) where T : class
+                => Task.CompletedTask;
+            public Task<IOperationResult> DeleteAsync<T>(T entity, CancellationToken token = default) where T : class
+                => Task.FromResult(OperationResult.Success);
+            public Task<T?> FindAsync<T>(System.Linq.Expressions.Expression<Func<T, bool>> predicate, CancellationToken token = default) where T : class
+                => Task.FromResult<T?>(null);
+            public IQueryable<T> Query<T>() where T : class => throw new NotImplementedException();
+        }
+
+        private sealed class FakeUnitOfWork : IUnitOfWork
+        {
+            public bool IsManaged { get; set; }
+            public bool HasActiveTransaction => false;
+            public void BeginManage() { IsManaged = true; }
+            public Task<bool> CommitTransactionAsync(Guid transactionId, CancellationToken token = default)
+                => Task.FromResult(true);
+            public Task<int> SaveChangesAsync(CancellationToken token = default) => Task.FromResult(0);
+            public Task AddAsync<T>(T entity, CancellationToken token = default) where T : class
+                => Task.CompletedTask;
+            public Task AddRangeAsync<T>(IEnumerable<T> entities, CancellationToken token = default) where T : class
+                => Task.CompletedTask;
+            public Task<IOperationResult> DeleteAsync<T>(T entity, CancellationToken token = default) where T : class
+                => Task.FromResult(OperationResult.Success);
+            public Task<T?> FindAsync<T>(System.Linq.Expressions.Expression<Func<T, bool>> predicate, CancellationToken token = default) where T : class
+                => Task.FromResult<T?>(null);
+            public IQueryable<T> Query<T>() where T : class => throw new NotImplementedException();
+        }
+
+        private sealed class OutboxTracker
+        {
+            public bool AddEventCalled { get; set; }
+            public bool SaveEventsCalled { get; set; }
+        }
+
+        private sealed class TrackingOutboxService : IOutboxService<FakeDbContext>
+        {
+            private readonly OutboxTracker _tracker;
+            public TrackingOutboxService(OutboxTracker tracker) => _tracker = tracker;
+
+            public ValueTask AddEventAsync(IMessage message)
+            {
+                _tracker.AddEventCalled = true;
+                return ValueTask.CompletedTask;
+            }
+
+            public ValueTask SaveEventsAsync(Guid? transactionId, CancellationToken cancellationToken = default)
+            {
+                _tracker.SaveEventsCalled = true;
+                return ValueTask.CompletedTask;
+            }
+        }
+
+        private sealed class FixedRoutePolicy(string publisherKey, string destination)
+            : IMessagePublishingPolicy
+        {
+            public ValueTask<IReadOnlyCollection<PublishRoute>> ResolveAsync(PolicyResolveContext context)
+            {
+                IReadOnlyCollection<PublishRoute> routes = [new PublishRoute(publisherKey, destination)];
+                return ValueTask.FromResult(routes);
+            }
+        }
+
+        private sealed class DualRoutePolicy : IMessagePublishingPolicy
+        {
+            public ValueTask<IReadOnlyCollection<PublishRoute>> ResolveAsync(PolicyResolveContext context)
+            {
+                IReadOnlyCollection<PublishRoute> routes =
+                [
+                    new PublishRoute("local-channel", string.Empty),
+                    new PublishRoute("local", string.Empty)
+                ];
+                return ValueTask.FromResult(routes);
+            }
+        }
+    }
+}

--- a/specs/003-local-channel-publisher/contracts/IMessageService-TContext.md
+++ b/specs/003-local-channel-publisher/contracts/IMessageService-TContext.md
@@ -39,10 +39,10 @@ namespace Juice.Messaging
 
 ## Transaction Behavior
 
-| Context | Action |
-|---|---|
-| Inside `TransactionBehavior` scope (`TContext.Database.CurrentTransaction != null`) | `IOutboxService<TContext>.AddEventAsync(msg)` only. `TransactionBehavior` commits via `SaveEventsAsync`. No immediate channel dispatch (transaction not yet committed). |
-| Outside active transaction | `AddEventAsync(msg)` + `SaveEventsAsync(null, ct)` immediately. Then, for `"local"` routes, enqueue to channel for immediate dispatch (idempotency deduplicates with delivery retry). |
+| Context | Detection | Action |
+|---|---|---|
+| Inside managed `TransactionBehavior` scope | `TContext is IUnitOfWork { IsManaged: true }` | `AddEventAsync(msg)` only — save deferred to `TransactionBehavior.SaveEventsAsync(transactionId)`. No immediate channel dispatch (data not committed yet). `"local-channel"` routes still enqueue immediately. |
+| Outside managed transaction | `IsManaged = false`, or `TContext` is not `IUnitOfWork`, or `TContext` is null | `AddEventAsync(msg)` + `SaveEventsAsync(null, ct)` immediately. For `"local"` routes, enqueue to channel for immediate dispatch (idempotency deduplicates with delivery retry). |
 
 ---
 

--- a/specs/004-messageservice-transaction-aware/checklists/requirements.md
+++ b/specs/004-messageservice-transaction-aware/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Transaction-Aware IMessageService
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-15
+**Last Updated**: 2026-03-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows (inside transaction, outside transaction, local-channel)
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All checklist items pass. No [NEEDS CLARIFICATION] markers — the feature scope is well-defined from the codebase context (TransactionBehavior, IOutboxService, IMessageService interaction). Spec is ready for `/speckit.plan`.

--- a/specs/004-messageservice-transaction-aware/data-model.md
+++ b/specs/004-messageservice-transaction-aware/data-model.md
@@ -1,0 +1,51 @@
+# Data Model: Transaction-Aware IMessageService
+
+**Date**: 2026-03-15 | **Branch**: `004-messageservice-transaction-aware`
+
+---
+
+## No New Database Entities
+
+This feature introduces **zero new DB tables, columns, or EF migrations**. It modifies the runtime behavior of `MessageService<TContext>.PublishAsync` to detect transaction state and defer the outbox save — no schema changes.
+
+---
+
+## Existing Entities Used (no change)
+
+### `OutboxEvent` — unchanged
+
+Events staged by `IMessageService<TContext>.PublishAsync` inside a transaction are now saved by `TransactionBehavior.SaveEventsAsync(transactionId)` instead of `MessageService.SaveEventsAsync(null)`. The `TransactionId` field is populated correctly as a result.
+
+| Field | Inside transaction (before) | Inside transaction (after) |
+|---|---|---|
+| `TransactionId` | `null` (broken) | Transaction GUID (correct) |
+
+### `OutboxDelivery` — unchanged
+
+Delivery records are created by `OutboxEventService.SaveEventsAsync` as before. No change to delivery state machine or indexes.
+
+---
+
+## Modified Runtime Behavior
+
+### `MessageService<TContext>` — constructor change
+
+| Parameter | Before | After |
+|---|---|---|
+| `TContext` | Not injected | Optional injection (`TContext? context = null`) |
+
+### `MessageService<TContext>.PublishAsync` — decision branch
+
+```
+isManaged = _context is IUnitOfWork { IsManaged: true }
+
+if hasOutboxRoutes:
+    AddEventAsync(msg)           ← always
+    if isManaged:
+        skip SaveEventsAsync     ← defer to TransactionBehavior
+        skip channel enqueue     ← data not committed yet
+    else:
+        SaveEventsAsync(null)    ← immediate standalone save
+        if hasLocalOutbox:
+            EnqueueLocalChannel  ← immediate dispatch
+```

--- a/specs/004-messageservice-transaction-aware/plan.md
+++ b/specs/004-messageservice-transaction-aware/plan.md
@@ -1,0 +1,130 @@
+# Implementation Plan: Transaction-Aware IMessageService
+
+**Branch**: `004-messageservice-transaction-aware` | **Date**: 2026-03-15 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Make `IMessageService<TContext>.PublishAsync` transaction-aware: when called inside a `TransactionBehavior` scope (detected via `IUnitOfWork.IsManaged`), defer the outbox save to the behavior. When called outside a transaction, preserve existing immediate save behavior. No new interfaces, no new projects — a single code change in `MessageService<TContext>` with supporting tests.
+
+## Technical Context
+
+**Language/Version**: C# / .NET 6, 8, 9 (multi-targeted: `net6.0;net8.0;net9.0`)
+**Primary Dependencies**: `Juice.Messaging.Local`, `Juice.Messaging.Outbox`, `Juice.EF`, `Juice.MediatR.Behaviors`
+**Storage**: No new DB schema — uses existing `OutboxEvents` / `OutboxDeliveries` tables
+**Testing**: xUnit + `IgnoreOnCIFact`, `[InitializeMessageContext]`
+**Target Platform**: Library — consumed by ASP.NET Core host projects
+**Project Type**: Modification to existing NuGet library (`Juice.Messaging.Local`)
+**Performance Goals**: Zero overhead when outside transaction; negligible cost of `IsManaged` check inside transaction
+**Constraints**: No breaking API changes; no new interfaces; no circular dependencies
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Lightweight & Dual-Architecture | ✅ Pass | No new abstractions. Single check against existing `IsManaged` flag. Works in both monolith and microservice modes. |
+| II. Library-First Composability | ✅ Pass | Change is contained in `Juice.Messaging.Local` (existing project). No new libraries, no circular dependencies. `IUnitOfWork` is in `Juice` which `Juice.Messaging.Local` already references. |
+| III. DDD + CQRS | ✅ Pass | `TransactionBehavior` sequence preserved (SaveChanges → DispatchDomainEvents → SaveOutbox → Commit). `IMessageService` defers to the behavior, not the other way around. |
+| IV. Reliable Messaging via Outbox | ✅ Pass | Outbox atomicity is **improved** — events published via `IMessageService` inside a transaction are now correctly tagged with `transactionId` instead of being saved standalone. |
+| V. Multi-Tenancy First | ✅ Pass | No tenant-related changes. Tenant context flows unchanged. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-messageservice-transaction-aware/
+├── plan.md              ← this file
+├── research.md          ← Phase 0 output
+├── data-model.md        ← Phase 1 output (minimal — no new entities)
+└── tasks.md             ← /speckit.tasks output
+```
+
+### Source Code
+
+```text
+core/src/Juice.Messaging.Local/
+│   (existing — modify only)
+│   └── Internal/
+│       └── MessageServiceT.cs        ← MODIFY: add IsManaged check in PublishAsync
+
+core/test/Juice.Messaging.Local.Tests/
+│   (existing — add test)
+│   └── TransactionAwareTests.cs      ← NEW: test transaction-aware behavior
+```
+
+**Structure Decision**: No new projects. Single file modification (`MessageServiceT.cs`) + one new test file. The change resolves `TContext` from DI and checks `IUnitOfWork.IsManaged` to determine whether to call `SaveEventsAsync` or defer.
+
+---
+
+## Phase 0: Research
+
+### Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Transaction detection mechanism | Check `TContext` as `IUnitOfWork { IsManaged: true }` via DI-resolved instance | `IsManaged` is set by `TransactionBehavior.BeginManage()` and is the canonical signal. `HasActiveTransaction` checks raw EF transaction which could be a manual transaction unrelated to outbox. `IsManaged` is purpose-built. |
+| How to resolve `TContext` in `MessageService<TContext>` | Inject `TContext` directly (it's already scoped) or resolve via `IServiceProvider` | `TContext` is a scoped DbContext — inject directly in constructor. `MessageService<TContext>` already has `where TContext : class` constraint, and `IUnitOfWork` is in the `Juice` base package already referenced. |
+| Immediate channel dispatch inside transaction | Skip for `"local"` routes; allow for `"local-channel"` | `"local"` writes to outbox — cannot dispatch immediately before outbox is committed (data may not be visible to handler). `"local-channel"` is non-durable fire-and-forget — already accepted trade-off per spec 003. |
+| `IOutboxService` API change needed? | No — `AddEventAsync` + `SaveEventsAsync` remain unchanged | `MessageService<TContext>` just skips calling `SaveEventsAsync`. The scoped `IOutboxService<TContext>` accumulates events. `TransactionBehavior` calls `SaveEventsAsync(transactionId)` later — it picks up all accumulated events. |
+
+### Alternatives Considered
+
+1. **Add `IsInTransaction` property to `IOutboxService`**: Rejected — leaks transaction state into the outbox service, which is a messaging concern not a DB concern. The UoW pattern already provides this signal.
+2. **Use `Database.CurrentTransaction != null` on `TContext`**: Rejected — false positives from manual transactions. `IsManaged` is set explicitly by `TransactionBehavior` and is semantically correct.
+3. **Add a new `ITransactionContext` interface**: Rejected — unnecessary abstraction. `IUnitOfWork.IsManaged` already exists and is precisely what we need.
+
+---
+
+## Phase 1: Design
+
+### Modified Flow: `MessageService<TContext>.PublishAsync`
+
+```
+PublishAsync(IMessage msg)
+  │
+  ├─ ResolveAsync(PolicyResolveContext) → routes[]
+  │
+  ├─ [foreach route with key "local-channel"]
+  │     Channel<IMessage>.Writer.TryWrite(msg)     ← always, regardless of transaction
+  │
+  └─ [foreach route with key "local" or broker]
+        _outboxService.AddEventAsync(msg)           ← always stage the event
+        │
+        ├─ TContext is IUnitOfWork { IsManaged: true }?
+        │     YES → return (defer save to TransactionBehavior)
+        │     NO  → _outboxService.SaveEventsAsync(null, ct)
+        │            if hasLocalOutbox && !hasLocalChannel:
+        │                EnqueueLocalChannel(msg)    ← immediate dispatch only outside tx
+```
+
+### Constructor Change
+
+```
+MessageService<TContext> constructor adds:
+  + TContext? context = null   (optional — resolved from DI when TContext is a DbContext)
+
+PublishAsync uses:
+  var isManaged = _context is IUnitOfWork { IsManaged: true };
+```
+
+`TContext` is constrained as `where TContext : class` in `IMessageService<TContext>`. The constructor takes it as optional — if `TContext` is not registered in DI (unlikely but defensive), it falls back to the existing behavior (save immediately).
+
+### No New Data Model
+
+No new entities, tables, or schemas. The existing `OutboxEvent` and `OutboxDelivery` tables are unchanged. The `transactionId` field on `OutboxEvent` is already populated by `TransactionBehavior` — this change ensures events from `IMessageService.PublishAsync` are included in that save.
+
+### Critical Implementation Notes
+
+**Scoped `IOutboxService<TContext>` sharing**: Both `TransactionBehavior` and `MessageService<TContext>` resolve `IOutboxService<TContext>` from the same DI scope. They share the same `OutboxEventService<TContext>` instance, which has a single `_messages` list. Events added by `IMessageService.PublishAsync` (via `AddEventAsync`) are accumulated in the same list as events added directly by domain event handlers. When `TransactionBehavior` calls `SaveEventsAsync(transactionId)`, it persists **all** accumulated events.
+
+**No `_messages.Clear()` conflict**: `SaveEventsAsync` clears `_messages` after saving. When `MessageService` defers (doesn't call `SaveEventsAsync`), the messages remain in the list until `TransactionBehavior` saves them. This is correct — no double-save, no orphaned messages.
+
+**`"local-channel"` inside transaction**: Enqueuing to the channel is allowed even inside a transaction. The handler may run before the transaction commits and see stale data. This is documented and accepted in spec 003 — `"local-channel"` is explicitly non-durable and non-transactional.
+
+---
+
+## Complexity Tracking
+
+No violations. No new projects, interfaces, or abstractions. Single behavioral change in existing code.

--- a/specs/004-messageservice-transaction-aware/research.md
+++ b/specs/004-messageservice-transaction-aware/research.md
@@ -1,0 +1,64 @@
+# Research: Transaction-Aware IMessageService
+
+**Date**: 2026-03-15 | **Branch**: `004-messageservice-transaction-aware`
+
+---
+
+## R1: Transaction Detection Mechanism
+
+**Decision**: Use `IUnitOfWork.IsManaged` property on the resolved `TContext` instance.
+
+**Rationale**: `IsManaged` is set by `TransactionBehavior.BeginManage()` at the start of the managed transaction scope (before `next()` is called). It is the canonical signal that the current DbContext is being managed by the pipeline behavior. Alternatives:
+
+- `HasActiveTransaction` (`Database.CurrentTransaction != null`) — checks raw EF transaction, which could be a manual transaction created by application code unrelated to the outbox pattern. False positives.
+- `Database.CurrentTransaction.TransactionId` — requires EF dependency in the detection logic and still can't distinguish managed vs. manual transactions.
+- Custom `AsyncLocal<bool>` flag — unnecessary complexity when `IsManaged` already exists at the right abstraction level.
+
+**Alternatives considered**:
+1. Add `bool IsInTransaction` to `IOutboxService` — rejected: leaks transaction awareness into the messaging layer, which should not know about DB transactions.
+2. Add `ITransactionScope` interface — rejected: YAGNI, `IUnitOfWork.IsManaged` is sufficient.
+
+---
+
+## R2: Constructor Injection of TContext
+
+**Decision**: Inject `TContext` as an optional constructor parameter in `MessageService<TContext>`.
+
+**Rationale**: `TContext` is a scoped service (DbContext). The generic constraint is `where TContext : class`, so it may or may not implement `IUnitOfWork`. The `is IUnitOfWork { IsManaged: true }` pattern check handles both cases:
+- If `TContext` implements `IUnitOfWork` (the normal case with `DbContextBase`), the check works.
+- If `TContext` does not implement `IUnitOfWork` (unusual), the pattern match fails and falls back to the existing behavior (save immediately).
+- If `TContext` is not resolvable from DI (defensive edge case), the parameter defaults to `null` and falls back to save immediately.
+
+This approach requires no changes to `IMessageService<TContext>` interface or `IOutboxService`.
+
+**Alternatives considered**:
+1. Resolve `TContext` via `IServiceProvider.GetService<TContext>()` at publish time — rejected: constructor injection is simpler, testable, and follows established DI patterns.
+2. Pass transaction state via `IOutboxService` — rejected: see R1.
+
+---
+
+## R3: Immediate Dispatch Suppression Inside Transaction
+
+**Decision**: When inside a managed transaction, suppress immediate channel dispatch for `"local"` routes. Allow `"local-channel"` dispatch regardless.
+
+**Rationale**:
+- `"local"` writes to the outbox. If we dispatch immediately before the transaction commits, the handler may read data that hasn't been committed yet — or the transaction may roll back, leaving the handler having processed phantom data. After rollback, the outbox record is also gone, so no retry occurs.
+- `"local-channel"` is non-durable by design. It never writes to the outbox. The channel dispatch is fire-and-forget. This trade-off is already accepted in spec 003.
+- After the transaction commits, `DeliveryHostedService` picks up the outbox records and dispatches via `LocalTransportPublisher` — this is the correct, safe path for `"local"` routes inside transactions.
+
+**Alternatives considered**:
+1. Dispatch `"local"` immediately inside transaction anyway (relying on idempotency) — rejected: handler sees uncommitted data; if transaction rolls back, handler already processed invalid state.
+2. Post-commit hook to dispatch immediately after commit — deferred: adds complexity to `TransactionBehavior`; the delivery service polling interval is acceptable for transactional flows.
+
+---
+
+## R4: Shared IOutboxService Instance Verification
+
+**Decision**: Rely on the existing scoped DI lifetime — no changes needed.
+
+**Rationale**: Both `TransactionBehavior` and `MessageService<TContext>` resolve `IOutboxService<TContext>` from the same DI scope. `OutboxEventService<TContext>` is registered as scoped, so both receive the same instance with a shared `_messages` list. Events added by `MessageService<TContext>.PublishAsync` (via `AddEventAsync`) accumulate in the same list as events added directly by domain event handlers. When `TransactionBehavior` calls `SaveEventsAsync(transactionId)`, all accumulated events are saved atomically.
+
+Verified by reading:
+- `OutboxServiceCollectionExtensions.AddOutboxCore()`: registers `IOutboxService<>` as scoped
+- `OutboxEventService<TContext>._messages`: instance-level `IList<IMessage>`
+- `SaveEventsAsync`: clears `_messages` after saving — no double-save risk

--- a/specs/004-messageservice-transaction-aware/spec.md
+++ b/specs/004-messageservice-transaction-aware/spec.md
@@ -1,0 +1,98 @@
+# Feature Specification: Transaction-Aware IMessageService
+
+**Feature Branch**: `004-messageservice-transaction-aware`
+**Created**: 2026-03-15
+**Status**: Draft
+**Input**: Handle case using IMessageService<T> inside transaction behavior via domain event handler, message service will check outboxservice is inside transaction to decide save event or not
+
+## Overview
+
+When `IMessageService<TContext>.PublishAsync` is called inside a `TransactionBehavior` scope (e.g., from a domain event handler dispatched during the transaction), it currently calls `SaveEventsAsync(null)` immediately — breaking the atomic outbox commit. This feature makes `IMessageService<TContext>` transaction-aware: it detects the active managed transaction and defers the save to `TransactionBehavior`, preserving atomicity.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Publish via IMessageService Inside TransactionBehavior (Priority: P1)
+
+A developer uses `IMessageService<TContext>.PublishAsync` inside a domain event handler that runs within `TransactionBehavior`. The message service detects the active managed transaction and only stages the event via `AddEventAsync` — it does **not** call `SaveEventsAsync`. The `TransactionBehavior` saves all staged events atomically with the domain data when it calls `SaveEventsAsync(transactionId)` at commit time.
+
+**Why this priority**: This is the core problem. Without it, events published via `IMessageService` inside a transaction break atomicity — they are saved with `transactionId=null` and committed independently from the domain data.
+
+**Independent Test**: Inside a `TransactionBehavior` scope, call `IMessageService<TContext>.PublishAsync` from a domain event handler. Verify the outbox record has the correct `transactionId` (not null) and is committed atomically with the domain entity changes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a command handler running inside `TransactionBehavior` raises a domain event, **When** the domain event handler calls `IMessageService<TContext>.PublishAsync`, **Then** the message is staged via `AddEventAsync` only — `SaveEventsAsync` is NOT called by `IMessageService`.
+2. **Given** events staged by `IMessageService<TContext>` during domain event dispatch, **When** `TransactionBehavior` reaches its commit phase, **Then** `SaveEventsAsync(transactionId)` persists all staged events (both from direct `IOutboxService.AddEventAsync` and from `IMessageService.PublishAsync`) atomically with domain data.
+3. **Given** events staged by `IMessageService<TContext>` during domain event dispatch, **When** the transaction rolls back, **Then** no outbox records are persisted — the staged events are discarded along with the domain changes.
+
+---
+
+### User Story 2 - Publish via IMessageService Outside TransactionBehavior (Priority: P1)
+
+A developer calls `IMessageService<TContext>.PublishAsync` outside any `TransactionBehavior` scope (e.g., from a background job, API controller, or standalone service). The message service detects there is no active managed transaction and calls `SaveEventsAsync(null)` immediately as a standalone operation — existing behavior preserved.
+
+**Why this priority**: Equal to US1 — the outside-transaction path must continue to work correctly. This is the existing behavior that must not regress.
+
+**Independent Test**: Call `IMessageService<TContext>.PublishAsync` without any active transaction. Verify the outbox record is saved immediately with `transactionId=null`.
+
+**Acceptance Scenarios**:
+
+1. **Given** no active `TransactionBehavior` scope, **When** `IMessageService<TContext>.PublishAsync` is called, **Then** the event is staged and saved immediately via `SaveEventsAsync(null)`.
+2. **Given** no active `TransactionBehavior` scope with a `"local"` route, **When** `IMessageService<TContext>.PublishAsync` is called, **Then** the event is also enqueued to the in-memory channel for immediate dispatch (existing behavior preserved).
+
+---
+
+### User Story 3 - Local-Channel Route Unaffected by Transaction State (Priority: P2)
+
+A developer publishes a message routed to `"local-channel"` inside a `TransactionBehavior` scope. The `"local-channel"` route bypasses the outbox entirely — it enqueues to the in-memory channel regardless of transaction state. This behavior is unchanged.
+
+**Why this priority**: Ensures the non-durable path is unaffected by the transaction detection logic.
+
+**Independent Test**: Inside a `TransactionBehavior` scope, publish an event with `"local-channel"` route. Verify it is enqueued to the channel immediately and no outbox record is written.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active `TransactionBehavior` scope, **When** `IMessageService.PublishAsync` is called with a `"local-channel"` route, **Then** the event is enqueued to the in-memory channel immediately — no outbox involvement.
+2. **Given** a policy that resolves both `"local-channel"` and `"local"` routes, **When** `IMessageService<TContext>.PublishAsync` is called inside a transaction, **Then** the `"local-channel"` portion is enqueued immediately AND the `"local"` portion is staged for deferred save.
+
+---
+
+### Edge Cases
+
+- What happens if `IMessageService<TContext>.PublishAsync` is called after `TransactionBehavior` has already called `SaveEventsAsync(transactionId)` but before `CommitTransactionAsync`? The event would be staged but not saved in this transaction — it would be orphaned. This should not happen in practice because domain event dispatch occurs before the save phase.
+- What happens if the `DbContext` has an active transaction but is NOT managed by `TransactionBehavior` (e.g., manual `BeginTransaction`)? The message service should detect the managed state, not just the raw transaction presence.
+- What happens if `IMessageService<TContext>` is called multiple times during the same transaction? All events should accumulate in the same `IOutboxService<TContext>` (scoped) and be saved together by `TransactionBehavior`.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `IMessageService<TContext>.PublishAsync` MUST detect whether the `DbContext` (`TContext`) is currently managed by `TransactionBehavior`. When managed, it MUST only call `AddEventAsync` — it MUST NOT call `SaveEventsAsync`.
+- **FR-002**: When `IMessageService<TContext>.PublishAsync` is called outside a managed transaction, it MUST call both `AddEventAsync` and `SaveEventsAsync(null)` immediately — preserving the existing standalone behavior.
+- **FR-003**: `"local-channel"` route enqueuing MUST be unaffected by transaction state — it MUST always enqueue to the channel immediately regardless of whether a transaction is active.
+- **FR-004**: When inside a managed transaction with a `"local"` route, `IMessageService<TContext>` MUST NOT enqueue to the channel for immediate dispatch. The immediate dispatch MUST only happen in the outside-transaction path (after `SaveEventsAsync` commits the outbox standalone).
+- **FR-005**: The transaction detection MUST use the managed state set by `TransactionBehavior` (e.g., `DbContext.BeginManage()` / `HasActiveTransaction`), not raw EF `Database.CurrentTransaction`, to avoid false positives from manual transactions unrelated to the outbox.
+- **FR-006**: All events staged via `IMessageService<TContext>.PublishAsync` during a managed transaction MUST be persisted by `TransactionBehavior`'s `SaveEventsAsync(transactionId)` call — tagged with the correct `transactionId` for post-commit delivery.
+
+### Key Entities
+
+- **IMessageService\<TContext\>**: Unified publishing interface. Must become transaction-aware — detect managed transaction and defer save.
+- **IOutboxService\<TContext\>**: Scoped service that accumulates events. Shared between `TransactionBehavior` (direct `AddEventAsync` from domain handlers) and `IMessageService<TContext>` (via `PublishAsync`). Same instance within the request scope.
+- **TransactionBehavior**: Pipeline behavior that manages the DB transaction, dispatches domain events, and calls `SaveEventsAsync(transactionId)` atomically.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Events published via `IMessageService<TContext>.PublishAsync` inside a `TransactionBehavior` scope are persisted with the correct `transactionId` — verified by querying outbox records after commit.
+- **SC-002**: Events published via `IMessageService<TContext>.PublishAsync` inside a `TransactionBehavior` scope are rolled back when the transaction fails — verified by asserting zero outbox records after a failed transaction.
+- **SC-003**: Events published via `IMessageService<TContext>.PublishAsync` outside a transaction are saved immediately — verified by querying outbox records before any background delivery runs.
+- **SC-004**: Existing tests for `TransactionBehavior`, `IOutboxService`, and `IMessageService` continue to pass without modification.
+- **SC-005**: No breaking API changes — `IMessageService`, `IOutboxService`, and `TransactionBehavior` public interfaces remain unchanged.
+
+## Assumptions
+
+- The `IOutboxService<TContext>` instance is **scoped** — the same instance is shared between `TransactionBehavior` and `IMessageService<TContext>` within a single request scope. Events staged by `IMessageService.PublishAsync` are accumulated in the same `_messages` list as events staged by direct `AddEventAsync` calls from domain event handlers.
+- `TransactionBehavior` always calls `SaveEventsAsync(transactionId)` after domain event dispatch (step 7 in the flow). Any events added during dispatch (whether via `IOutboxService.AddEventAsync` directly or via `IMessageService.PublishAsync`) will be included.
+- The transaction detection mechanism uses the `DbContext`'s managed state (set by `BeginManage()`) rather than raw EF transaction presence, to avoid interference with manual transactions not related to outbox processing.
+- `"local-channel"` enqueue inside a transaction is intentionally allowed — it is non-durable by design, and the handler may run before the transaction commits. This is an accepted trade-off documented in the local transport spec.

--- a/specs/004-messageservice-transaction-aware/tasks.md
+++ b/specs/004-messageservice-transaction-aware/tasks.md
@@ -1,0 +1,147 @@
+# Tasks: Transaction-Aware IMessageService
+
+**Input**: Design documents from `specs/004-messageservice-transaction-aware/`
+**Branch**: `004-messageservice-transaction-aware`
+**Stack**: C# / .NET 6, 8, 9 — existing library `core/src/Juice.Messaging.Local`
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: User story this task belongs to (US1–US3)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No new projects — verify prerequisites and prepare test infrastructure.
+
+- [X] T001 Verify `Juice.Messaging.Local` project references `Juice` (for `IUnitOfWork`) — check `core/src/Juice.Messaging.Local/Juice.Messaging.Local.csproj`
+- [X] T002 Create `core/test/Juice.Messaging.Local.Tests/TransactionAwareTests.cs` — empty test class with standard imports, `ITestOutputHelper`, and `BuildServices` helper
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Modify `MessageService<TContext>` constructor to accept `TContext` for transaction detection.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T003 Update `MessageService<TContext>` constructor in `core/src/Juice.Messaging.Local/Internal/MessageServiceT.cs` — add optional `TContext? context = null` parameter; store as `private readonly TContext? _context`
+- [X] T004 Update `AddMessageService<TContext>()` DI registration in `core/src/Juice.Messaging.Local/DependencyInjection/LocalMessagingBuilderExtensions.cs` — ensure `TContext` is resolved and passed to `MessageService<TContext>` constructor (it's already available as a scoped service when `TContext` is a `DbContext`)
+
+**Checkpoint**: Constructor change complete — `MessageService<TContext>` has access to `TContext` instance for transaction detection.
+
+---
+
+## Phase 3: User Story 1 — Publish Inside TransactionBehavior (Priority: P1) 🎯 MVP
+
+**Goal**: When `IMessageService<TContext>.PublishAsync` is called inside a `TransactionBehavior` scope, defer the outbox save — only call `AddEventAsync`, let `TransactionBehavior` handle `SaveEventsAsync(transactionId)`.
+
+**Independent Test**: Inside a `TransactionBehavior` scope, call `IMessageService<TContext>.PublishAsync` from a domain event handler. Verify the event is staged but NOT saved immediately. Verify `TransactionBehavior`'s `SaveEventsAsync` picks it up.
+
+- [X] T005 [US1] Modify `PublishAsync` in `core/src/Juice.Messaging.Local/Internal/MessageServiceT.cs` — add `var isManaged = _context is IUnitOfWork { IsManaged: true };` check before the `SaveEventsAsync` call; when `isManaged` is true: call `AddEventAsync` only, skip `SaveEventsAsync`, skip channel enqueue for `"local"` routes
+- [X] T006 [US1] Add test `PublishAsync_InsideManagedTransaction_DefersToTransactionBehaviorAsync` in `core/test/Juice.Messaging.Local.Tests/TransactionAwareTests.cs` — mock `TContext` as `IUnitOfWork { IsManaged: true }`, call `PublishAsync`, assert `AddEventAsync` was called, assert `SaveEventsAsync` was NOT called
+- [X] T007 [US1] Add test `PublishAsync_InsideManagedTransaction_DoesNotEnqueueLocalChannelAsync` in `core/test/Juice.Messaging.Local.Tests/TransactionAwareTests.cs` — with `"local"` route and managed context, verify no message is enqueued to the channel
+
+**Checkpoint**: US1 complete — events published inside `TransactionBehavior` are deferred correctly.
+
+---
+
+## Phase 4: User Story 2 — Publish Outside TransactionBehavior (Priority: P1)
+
+**Goal**: When `IMessageService<TContext>.PublishAsync` is called outside any managed transaction, preserve existing behavior — `AddEventAsync` + `SaveEventsAsync(null)` immediately + channel enqueue for `"local"` routes.
+
+**Independent Test**: Call `IMessageService<TContext>.PublishAsync` without a managed transaction. Verify `SaveEventsAsync` is called immediately and channel enqueue occurs for `"local"` routes.
+
+- [X] T008 [US2] Add test `PublishAsync_OutsideTransaction_SavesImmediatelyAsync` in `core/test/Juice.Messaging.Local.Tests/TransactionAwareTests.cs` — with `TContext` that is NOT `IUnitOfWork` (or `IsManaged = false`), call `PublishAsync`, assert both `AddEventAsync` and `SaveEventsAsync` are called
+- [X] T009 [US2] Add test `PublishAsync_OutsideTransaction_EnqueuesLocalChannelAsync` in `core/test/Juice.Messaging.Local.Tests/TransactionAwareTests.cs` — with `"local"` route and non-managed context, verify message IS enqueued to the channel
+- [X] T010 [US2] Add test `PublishAsync_NullContext_SavesImmediatelyAsync` in `core/test/Juice.Messaging.Local.Tests/TransactionAwareTests.cs` — with `_context = null` (defensive), verify fallback to immediate save
+
+**Checkpoint**: US2 complete — outside-transaction behavior unchanged, no regression.
+
+---
+
+## Phase 5: User Story 3 — Local-Channel Unaffected by Transaction State (Priority: P2)
+
+**Goal**: `"local-channel"` routes always enqueue to the channel immediately regardless of whether a managed transaction is active. No outbox involvement.
+
+**Independent Test**: Inside a managed transaction, publish an event with `"local-channel"` route. Verify it is enqueued immediately. Publish with both `"local-channel"` and `"local"` routes inside a transaction — verify channel enqueue for the `"local-channel"` portion and deferred save for the `"local"` portion.
+
+- [X] T011 [US3] Add test `PublishAsync_LocalChannel_InsideTransaction_EnqueuesImmediatelyAsync` in `core/test/Juice.Messaging.Local.Tests/TransactionAwareTests.cs` — with managed context and `"local-channel"` route, verify message IS enqueued to channel
+- [X] T012 [US3] Add test `PublishAsync_DualRoute_InsideTransaction_ChannelEnqueuedAndOutboxDeferredAsync` in `core/test/Juice.Messaging.Local.Tests/TransactionAwareTests.cs` — with managed context and both `"local-channel"` + `"local"` routes, verify channel enqueue AND deferred outbox save
+
+**Checkpoint**: US3 complete — `"local-channel"` behavior is independent of transaction state.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T013 [P] Update XML doc comments on `MessageService<TContext>.PublishAsync` in `core/src/Juice.Messaging.Local/Internal/MessageServiceT.cs` — document the transaction-aware branching behavior
+- [X] T014 [P] Update spec `specs/003-local-channel-publisher/contracts/IMessageService-TContext.md` — add transaction-aware behavior row in the Transaction Behavior table
+- [X] T015 Run all existing `Juice.Messaging.Local.Tests` to confirm no regressions — all 11 existing tests must pass
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1 — **BLOCKS all user stories**
+- **Phase 3 (US1)**: Depends on Phase 2
+- **Phase 4 (US2)**: Depends on Phase 2; independent of US1
+- **Phase 5 (US3)**: Depends on Phase 2; independent of US1/US2
+- **Phase 6 (Polish)**: Depends on all story phases complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Foundational only — independent of other stories
+- **US2 (P1)**: Depends on Foundational only — independent of other stories (tests the non-managed path)
+- **US3 (P2)**: Depends on Foundational only — independent (tests `"local-channel"` behavior)
+
+### Within Each Story
+
+- Implementation (T005) before tests (T006, T007) — implementation is a single code change
+- Tests verify the behavior after the branch logic is in place
+
+### Parallel Opportunities
+
+**After Phase 2 completes**:
+```
+Developer A: US1 (T005 → T006 → T007)
+Developer B: US2 (T008 → T009 → T010)
+Developer C: US3 (T011 → T012)
+```
+
+All three stories modify different test methods in the same test file but the implementation change (T005) is shared. In practice, T005 is the single implementation change — US2 and US3 tests verify the same code path with different inputs.
+
+**Phase 6**: T013 and T014 are parallel (different files).
+
+---
+
+## Implementation Strategy
+
+### MVP (US1 — Deferred Save Inside Transaction)
+
+1. Complete Phase 1: Setup (T001–T002)
+2. Complete Phase 2: Foundational (T003–T004)
+3. Complete Phase 3: US1 (T005–T007)
+4. **STOP and VALIDATE**: Run all tests — 11 existing + 2 new must pass
+5. This alone fixes the atomicity bug
+
+### Incremental Delivery
+
+1. Phase 1 + 2 → Constructor ready
+2. Phase 3 (US1) → Managed transaction path works ✅ (MVP!)
+3. Phase 4 (US2) → Outside-transaction regression verified ✅
+4. Phase 5 (US3) → Local-channel independence verified ✅
+5. Phase 6 → Docs updated, full regression confirmed
+
+---
+
+## Notes
+
+- **Single implementation change**: T005 is the only production code modification — it adds a 3-line branch (`if isManaged → skip save + skip channel`). All other tasks are tests or docs.
+- The `_context is IUnitOfWork { IsManaged: true }` pattern check handles all cases: `TContext` implements `IUnitOfWork` (normal), doesn't implement it (falls through to existing behavior), or is null (defensive fallback).
+- `IOutboxService<TContext>` is scoped — same instance shared between `TransactionBehavior` and `MessageService<TContext>`. Events added by `PublishAsync` accumulate in the same `_messages` list.
+- Existing 11 tests in `Juice.Messaging.Local.Tests` must continue to pass — they use `[InitializeMessageContext]` which does not set `IsManaged`, so they exercise the outside-transaction path.


### PR DESCRIPTION
…ispatch

- IMessageService<TContext>.PublishAsync detects managed TransactionBehavior scope via IUnitOfWork.IsManaged and defers outbox save — only calls AddEventAsync, letting TransactionBehavior persist atomically
- Add IPostCommitActions scoped service for deferred channel enqueue: MessageService registers EnqueueLocalChannel as post-commit action, TransactionBehavior flushes after CommitTransactionAsync
- "local-channel" and "local" routes are now mutually exclusive — "local" supersedes "local-channel" to prevent double handler invocation
- Add Juice project reference to Juice.Messaging.Local for IUnitOfWork
- Add 7 transaction-aware tests in TransactionAwareTests.cs (18 total tests passing across net6/8/9)
- Add specs/004-messageservice-transaction-aware (spec, plan, tasks, research)