### PR TITLE
feat: use subscriptions manager for local/local-channel handler lookup

### DIFF
--- a/core/src/Juice.EventBus/DependencyInjection/EventBusServiceCollectionExtensions.cs
+++ b/core/src/Juice.EventBus/DependencyInjection/EventBusServiceCollectionExtensions.cs
@@ -27,6 +27,26 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.AddDefaultServices();
             return builder;
         }
+
+        /// <summary>
+        /// Registers the keyed <see cref="ISubscriptionsManager"/> (key <c>"local"</c>) for
+        /// in-process dispatch routes (<c>"local"</c> and <c>"local-channel"</c>).
+        /// The manager is populated from all <see cref="ILocalSubscriptionsProvider"/> instances
+        /// registered in the container (added by <c>AddLocalConsumer</c>).
+        /// Safe to call multiple times — subsequent calls are no-ops.
+        /// </summary>
+        public static IServiceCollection AddLocalSubscriptionsManager(this IServiceCollection services)
+        {
+            services.TryAddKeyedSingleton<ISubscriptionsManager>("local", (sp, k) =>
+            {
+                var logger = sp.GetRequiredService<ILoggerFactory>()
+                    .CreateLogger(typeof(InMemorySubscriptionsManager).Name + "[local]");
+                var providers = sp.GetServices<ILocalSubscriptionsProvider>()
+                    .Cast<ISubscriptionsProvider>();
+                return new InMemorySubscriptionsManager(providers, logger, topicSupport: false);
+            });
+            return services;
+        }
     }
 
     public class EventBusBuilder

--- a/core/src/Juice.EventBus/Subscriptions/ILocalSubscriptionsProvider.cs
+++ b/core/src/Juice.EventBus/Subscriptions/ILocalSubscriptionsProvider.cs
@@ -1,0 +1,12 @@
+namespace Juice.EventBus.Subscriptions
+{
+    /// <summary>
+    /// Marker interface for subscription providers that supply handler registrations
+    /// for in-process (<c>"local"</c> / <c>"local-channel"</c>) dispatch routes.
+    /// Keeping these registrations separate from <see cref="ISubscriptionsProvider"/>
+    /// prevents them from being picked up by broker (e.g. RabbitMQ) consumer managers.
+    /// </summary>
+    public interface ILocalSubscriptionsProvider : ISubscriptionsProvider
+    {
+    }
+}

--- a/core/src/Juice.Messaging.Local/DependencyInjection/LocalMessagingBuilderExtensions.cs
+++ b/core/src/Juice.Messaging.Local/DependencyInjection/LocalMessagingBuilderExtensions.cs
@@ -1,13 +1,13 @@
 ﻿using System.Threading.Channels;
+using Juice.EventBus.Subscriptions;
 using Juice.EventBus.Publishing;
 using Juice.Messaging.Local;
 using Juice.Messaging.Local.Internal;
 using Juice.Messaging.Publishing;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+using Juice.Messaging;
 
-namespace Juice.Messaging
+namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Extension methods on <see cref="MessagingBuilder"/> that register the local transport
@@ -79,6 +79,34 @@ namespace Juice.Messaging
 
             builder.Services.AddHostedService<LocalChannelBackgroundService>();
 
+            return builder;
+        }
+
+        /// <summary>
+        /// Registers handlers for in-process integration events dispatched on the
+        /// <c>"local"</c> and <c>"local-channel"</c> routes, and ensures the keyed
+        /// <see cref="ISubscriptionsManager"/> (key <c>"local"</c>) is registered.
+        /// <para>
+        /// Each call to <paramref name="configure"/> adds subscriptions to the manager.
+        /// Multiple calls to <see cref="AddLocalConsumer"/> are additive — each registers
+        /// an additional <see cref="ILocalSubscriptionsProvider"/> that is picked up when
+        /// the manager is first resolved.
+        /// </para>
+        /// <para>
+        /// When the manager is registered, <c>LocalChannelBackgroundService</c> and
+        /// <c>LocalTransportPublisher</c> use it exclusively for handler lookup.
+        /// If <see cref="AddLocalConsumer"/> is never called, both dispatch paths fall back
+        /// to discovering handlers from the DI container (backward-compatible behavior).
+        /// </para>
+        /// </summary>
+        public static MessagingBuilder AddLocalConsumer(
+            this MessagingBuilder builder,
+            Action<LocalConsumerBuilder> configure)
+        {
+            var consumerBuilder = new LocalConsumerBuilder(builder.Services);
+            configure(consumerBuilder);
+            builder.Services.AddSingleton<ILocalSubscriptionsProvider>(consumerBuilder);
+            builder.Services.AddLocalSubscriptionsManager();
             return builder;
         }
 

--- a/core/src/Juice.Messaging.Local/Internal/LocalChannelBackgroundService.cs
+++ b/core/src/Juice.Messaging.Local/Internal/LocalChannelBackgroundService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Threading.Channels;
+using Juice.EventBus.Subscriptions;
 using Juice.MediatR;
 using Juice.Messaging.Integrations;
 using Microsoft.Extensions.DependencyInjection;
@@ -108,7 +109,8 @@ namespace Juice.Messaging.Local.Internal
                         {
                             _logger.LogDebug("Dispatching IIntegrationEvent {MessageType}", message.GetType().Name);
                             var dispatcher = sp.GetRequiredService<IntegrationEventDispatcher>();
-                            await LocalDispatchHelper.DispatchIntegrationEventAsync(sp, dispatcher, integrationEvent, CancellationToken.None);
+                            var subsManager = sp.GetKeyedService<ISubscriptionsManager>("local");
+                            await LocalDispatchHelper.DispatchIntegrationEventAsync(sp, dispatcher, subsManager, integrationEvent, CancellationToken.None);
                         }
                         else
                         {

--- a/core/src/Juice.Messaging.Local/Internal/LocalConsumerBuilder.cs
+++ b/core/src/Juice.Messaging.Local/Internal/LocalConsumerBuilder.cs
@@ -1,0 +1,48 @@
+using Juice.EventBus.Subscriptions;
+using Juice.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Juice.Messaging.Local.Internal
+{
+    /// <summary>
+    /// Builder for registering in-process integration event handlers with the local
+    /// subscriptions manager. Each <see cref="Subscribe{TEvent,THandler}"/> call:
+    /// <list type="bullet">
+    ///   <item>Records the <c>(TEvent → THandler)</c> binding in the subscriptions manager.</item>
+    ///   <item>Registers <typeparamref name="THandler"/> as a transient DI service.</item>
+    /// </list>
+    /// Instances are created by <c>AddLocalConsumer</c> and registered as
+    /// <see cref="ILocalSubscriptionsProvider"/> singletons, making them available
+    /// to <see cref="Microsoft.Extensions.DependencyInjection.EventBusServiceCollectionExtensions.AddLocalSubscriptionsManager"/>.
+    /// </summary>
+    public sealed class LocalConsumerBuilder : ILocalSubscriptionsProvider
+    {
+        private readonly IServiceCollection _services;
+        private readonly List<SubscriptionInfo> _subscriptions = new();
+
+        internal LocalConsumerBuilder(IServiceCollection services)
+        {
+            _services = services;
+        }
+
+        /// <summary>
+        /// Registers <typeparamref name="THandler"/> to handle events of type
+        /// <typeparamref name="TEvent"/> on local and local-channel routes.
+        /// </summary>
+        /// <param name="key">
+        /// Optional routing key override. Defaults to <c>typeof(TEvent).Name</c>.
+        /// </param>
+        public LocalConsumerBuilder Subscribe<TEvent, THandler>(string? key = null)
+            where TEvent : IIntegrationEvent
+            where THandler : class, IIntegrationEventHandler<TEvent>
+        {
+            _subscriptions.Add(SubscriptionInfo.Typed(typeof(TEvent), typeof(THandler), key));
+            _services.TryAddTransient<THandler>();
+            return this;
+        }
+
+        /// <inheritdoc />
+        IEnumerable<SubscriptionInfo> ISubscriptionsProvider.GetSubscriptions() => _subscriptions;
+    }
+}

--- a/core/src/Juice.Messaging.Local/Internal/LocalDispatchHelper.cs
+++ b/core/src/Juice.Messaging.Local/Internal/LocalDispatchHelper.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Collections.Concurrent;
+using Juice.EventBus.Subscriptions;
 using Juice.MediatR;
 using Juice.Messaging.Integrations;
 using Microsoft.Extensions.DependencyInjection;
@@ -32,22 +33,45 @@ namespace Juice.Messaging.Local.Internal
         }
 
         /// <summary>
-        /// Dispatches an <see cref="IIntegrationEvent"/> to all <c>IIntegrationEventHandler&lt;T&gt;</c>
-        /// implementations discovered from <paramref name="serviceProvider"/>.
+        /// Dispatches an <see cref="IIntegrationEvent"/> to handlers resolved via
+        /// <paramref name="subscriptionsManager"/> when available, or via a DI container
+        /// scan when <paramref name="subscriptionsManager"/> is <c>null</c> (backward-compatible
+        /// fallback for callers that have not registered <c>AddLocalConsumer</c>).
         /// Builds an <see cref="EventDispatchContext"/> from resolved handler types and delegates
         /// to <see cref="IntegrationEventDispatcher.DispatchAsync"/>.
         /// </summary>
+        /// <param name="serviceProvider">Scoped service provider for the current dispatch hop.</param>
+        /// <param name="dispatcher">Integration event dispatcher.</param>
+        /// <param name="subscriptionsManager">
+        /// Optional keyed subscriptions manager (key <c>"local"</c>). When non-null, only handlers
+        /// registered via <c>AddLocalConsumer</c> are invoked. When null, all
+        /// <c>IIntegrationEventHandler&lt;T&gt;</c> services in the DI container are invoked.
+        /// </param>
+        /// <param name="evt">The integration event to dispatch.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         public static async Task<EventDispatchResult> DispatchIntegrationEventAsync(
             IServiceProvider serviceProvider,
             IntegrationEventDispatcher dispatcher,
+            ISubscriptionsManager? subscriptionsManager,
             IIntegrationEvent evt,
             CancellationToken cancellationToken)
         {
-            var handlerType = typeof(IIntegrationEventHandler<>).MakeGenericType(evt.GetType());
-            var handlerTypes = serviceProvider
-                .GetServices(handlerType)
-                .Select(h => h!.GetType())
-                .ToList();
+            List<Type> handlerTypes;
+
+            if (subscriptionsManager != null)
+            {
+                var types = await subscriptionsManager.GetHandlersForEventAsync(evt.GetType().Name);
+                handlerTypes = types.ToList();
+            }
+            else
+            {
+                // Backward-compatible fallback: discover all handlers from DI.
+                var handlerType = typeof(IIntegrationEventHandler<>).MakeGenericType(evt.GetType());
+                handlerTypes = serviceProvider
+                    .GetServices(handlerType)
+                    .Select(h => h!.GetType())
+                    .ToList();
+            }
 
             var source = MessageContext.IsInitialized
                 ? MessageContext.Current.Source ?? string.Empty

--- a/core/src/Juice.Messaging.Local/Internal/LocalTransportPublisher.cs
+++ b/core/src/Juice.Messaging.Local/Internal/LocalTransportPublisher.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Concurrent;
 using System.Diagnostics;
 using Juice.EventBus.Publishing;
+using Juice.EventBus.Subscriptions;
 using Juice.MediatR;
 using Juice.Messaging.Integrations;
 using Microsoft.Extensions.DependencyInjection;
@@ -152,8 +153,9 @@ namespace Juice.Messaging.Local.Internal
                 else if (message is IIntegrationEvent integrationEvent)
                 {
                     using var scope = _scopeFactory.CreateScope();
+                    var subsManager = scope.ServiceProvider.GetKeyedService<ISubscriptionsManager>("local");
                     var result = await LocalDispatchHelper.DispatchIntegrationEventAsync(
-                        scope.ServiceProvider, _dispatcher, integrationEvent, cancellationToken);
+                        scope.ServiceProvider, _dispatcher, subsManager, integrationEvent, cancellationToken);
                     if (result == Integrations.EventDispatchResult.Failure)
                     {
                         throw new InvalidOperationException(

--- a/core/test/Juice.Messaging.Local.Tests/LocalChannelTests.cs
+++ b/core/test/Juice.Messaging.Local.Tests/LocalChannelTests.cs
@@ -1,9 +1,9 @@
 ﻿using System.Threading.Channels;
 using FluentAssertions;
-using Juice.MediatR;
 using Juice.Messaging;
 using Juice.Messaging.Local;
 using Juice.Messaging.Policies;
+using Juice.MediatR;
 using Juice.XUnit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -306,6 +306,120 @@ namespace Juice.Messaging.Local.Tests
             foreach (var hs in hostedServices) await hs.StopAsync(CancellationToken.None);
         }
 
+        // ─────────────────────────────────────────────────────────────────────
+        // US2-a: Subscriptions manager — registered handler is invoked
+        // ─────────────────────────────────────────────────────────────────────
+
+        [IgnoreOnCIFact]
+        [InitializeMessageContext]
+        public async Task LocalChannel_dispatches_to_registered_handler_via_subscriptions_manager_Async()
+        {
+            var handled = new TaskCompletionSource<bool>();
+
+            var services = new ServiceCollection();
+            services.AddLogging(b => b.AddTestOutputLogger(_output));
+            var m = services.AddMessaging();
+            m.AddLocalChannel();
+            m.AddIdempotencyInMemory();
+            m.AddDefaultMessageService(_ => { });
+            services.AddSingleton<IMessagePublishingPolicy>(new FixedRoutePolicy("local-channel", string.Empty));
+            services.AddMediatR();
+
+            // Pre-register the spy handler so TryAddTransient in Subscribe is a no-op
+            services.AddTransient<SubscriptionsManagerSpyHandler>(_ => new SubscriptionsManagerSpyHandler(handled));
+            // Register via AddLocalConsumer — this is what registers it in the subscriptions manager
+            m.AddLocalConsumer(c => c.Subscribe<TestIntegrationEvent, SubscriptionsManagerSpyHandler>());
+
+            var sp = services.BuildServiceProvider();
+            var hostedServices = sp.GetServices<IHostedService>().ToList();
+            using var cts = new CancellationTokenSource();
+            foreach (var hs in hostedServices) await hs.StartAsync(cts.Token);
+
+            var svc = sp.CreateScope().ServiceProvider.GetRequiredService<IMessageService>();
+            await svc.PublishAsync(new TestIntegrationEvent());
+
+            await handled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            handled.Task.Result.Should().BeTrue("handler registered via AddLocalConsumer must be invoked");
+
+            cts.Cancel();
+            foreach (var hs in hostedServices) await hs.StopAsync(CancellationToken.None);
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // US2-b: Handler in DI but not in subscriptions manager is NOT invoked
+        // ─────────────────────────────────────────────────────────────────────
+
+        [IgnoreOnCIFact]
+        [InitializeMessageContext]
+        public async Task LocalChannel_does_not_invoke_unregistered_handler_when_manager_present_Async()
+        {
+            var unregisteredHandlerInvoked = false;
+
+            var services = new ServiceCollection();
+            services.AddLogging(b => b.AddTestOutputLogger(_output));
+            var m = services.AddMessaging();
+            m.AddLocalChannel();
+            m.AddIdempotencyInMemory();
+            m.AddDefaultMessageService(_ => { });
+            services.AddSingleton<IMessagePublishingPolicy>(new FixedRoutePolicy("local-channel", string.Empty));
+            services.AddMediatR();
+
+            // Manager registered with NO subscription for TestIntegrationEvent
+            m.AddLocalConsumer(_ => { });
+
+            // Register spy directly in DI — NOT via AddLocalConsumer
+            services.AddTransient<IIntegrationEventHandler<TestIntegrationEvent>>(
+                _ => new SideEffectHandler(() => unregisteredHandlerInvoked = true));
+
+            var sp = services.BuildServiceProvider();
+            var hostedServices = sp.GetServices<IHostedService>().ToList();
+            using var cts = new CancellationTokenSource();
+            foreach (var hs in hostedServices) await hs.StartAsync(cts.Token);
+
+            var svc = sp.CreateScope().ServiceProvider.GetRequiredService<IMessageService>();
+            await svc.PublishAsync(new TestIntegrationEvent());
+
+            // Give background service time to dispatch
+            await Task.Delay(200);
+
+            unregisteredHandlerInvoked.Should().BeFalse(
+                "handler registered only in DI (not in subscriptions manager) must not be invoked");
+
+            cts.Cancel();
+            foreach (var hs in hostedServices) await hs.StopAsync(CancellationToken.None);
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // US2-c: Without AddLocalConsumer, DI-scan fallback still works
+        // ─────────────────────────────────────────────────────────────────────
+
+        [IgnoreOnCIFact]
+        [InitializeMessageContext]
+        public async Task LocalChannel_fallback_to_di_scan_when_no_manager_Async()
+        {
+            var handled = new TaskCompletionSource<bool>();
+
+            var provider = BuildServices(configureServices: svc =>
+            {
+                // No AddLocalConsumer call — DI-scan fallback must kick in
+                svc.AddTransient<IIntegrationEventHandler<TestIntegrationEvent>>(
+                    _ => new SignalingHandler(handled));
+            });
+
+            var hostedServices = provider.GetServices<IHostedService>().ToList();
+            using var cts = new CancellationTokenSource();
+            foreach (var hs in hostedServices) await hs.StartAsync(cts.Token);
+
+            var svc = provider.CreateScope().ServiceProvider.GetRequiredService<IMessageService>();
+            await svc.PublishAsync(new TestIntegrationEvent());
+
+            await handled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            handled.Task.Result.Should().BeTrue("DI-scan fallback must invoke handler when no subscriptions manager registered");
+
+            cts.Cancel();
+            foreach (var hs in hostedServices) await hs.StopAsync(CancellationToken.None);
+        }
+
         // ─── Supporting types ────────────────────────────────────────────────
 
         private sealed record TestIntegrationEvent : IntegrationEvent;
@@ -409,6 +523,33 @@ namespace Juice.Messaging.Local.Tests
             {
                 IReadOnlyCollection<PublishRoute> routes = [new PublishRoute(publisherKey, destination)];
                 return ValueTask.FromResult(routes);
+            }
+        }
+
+        /// <summary>
+        /// Spy handler registered via <c>AddLocalConsumer</c> for US2 subscriptions-manager dispatch tests.
+        /// </summary>
+        private sealed class SubscriptionsManagerSpyHandler(TaskCompletionSource<bool> signal)
+            : IIntegrationEventHandler<TestIntegrationEvent>
+        {
+            public Task HandleAsync(TestIntegrationEvent @event)
+            {
+                signal.TrySetResult(true);
+                return Task.CompletedTask;
+            }
+        }
+
+        /// <summary>
+        /// Handler that records a side-effect without signaling a TCS — used to assert
+        /// that a handler is NOT invoked when excluded from the subscriptions manager.
+        /// </summary>
+        private sealed class SideEffectHandler(Action onInvoke)
+            : IIntegrationEventHandler<TestIntegrationEvent>
+        {
+            public Task HandleAsync(TestIntegrationEvent @event)
+            {
+                onInvoke();
+                return Task.CompletedTask;
             }
         }
     }

--- a/core/test/Juice.Messaging.Local.Tests/LocalConsumerBuilderTests.cs
+++ b/core/test/Juice.Messaging.Local.Tests/LocalConsumerBuilderTests.cs
@@ -1,0 +1,160 @@
+﻿using FluentAssertions;
+using Juice.EventBus.Subscriptions;
+using Juice.Messaging.Local.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Juice.Messaging.Local.Tests
+{
+    /// <summary>
+    /// Unit tests for <see cref="LocalConsumerBuilder"/> and <c>AddLocalConsumer</c>
+    /// registration (US1: Register Local Handler via Subscriptions Manager).
+    /// No external infrastructure required.
+    /// </summary>
+    public class LocalConsumerBuilderTests
+    {
+        private static IServiceProvider BuildServices(Action<MessagingBuilder>? configure = null)
+        {
+            var services = new ServiceCollection();
+            services.AddLogging(b => b.SetMinimumLevel(LogLevel.Debug));
+            var messaging = services.AddMessaging();
+            configure?.Invoke(messaging);
+            return services.BuildServiceProvider();
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // US1-a: Registered handler is returned by GetHandlersForEventAsync
+        // ─────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task Subscribe_registers_handler_in_subscriptions_manager_Async()
+        {
+            var provider = BuildServices(m =>
+                m.AddLocalConsumer(c => c.Subscribe<TestEvent, TestHandler>()));
+
+            var manager = provider.GetRequiredKeyedService<ISubscriptionsManager>("local");
+            var handlers = await manager.GetHandlersForEventAsync(nameof(TestEvent));
+
+            handlers.Should().ContainSingle()
+                .Which.Should().Be(typeof(TestHandler));
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // US1-b: Duplicate Subscribe call does not double-register
+        // ─────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task Subscribe_is_idempotent_for_same_event_handler_pair_Async()
+        {
+            var provider = BuildServices(m =>
+                m.AddLocalConsumer(c =>
+                {
+                    c.Subscribe<TestEvent, TestHandler>();
+                    c.Subscribe<TestEvent, TestHandler>(); // duplicate
+                }));
+
+            var manager = provider.GetRequiredKeyedService<ISubscriptionsManager>("local");
+            var handlers = await manager.GetHandlersForEventAsync(nameof(TestEvent));
+
+            handlers.Should().ContainSingle("duplicate registration must be deduplicated");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // US1-c: Multiple handlers for same event are all returned
+        // ─────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task Multiple_handlers_for_same_event_are_all_returned_Async()
+        {
+            var provider = BuildServices(m =>
+                m.AddLocalConsumer(c =>
+                {
+                    c.Subscribe<TestEvent, TestHandler>();
+                    c.Subscribe<TestEvent, SecondTestHandler>();
+                }));
+
+            var manager = provider.GetRequiredKeyedService<ISubscriptionsManager>("local");
+            var handlers = (await manager.GetHandlersForEventAsync(nameof(TestEvent))).ToList();
+
+            handlers.Should().HaveCount(2);
+            handlers.Should().Contain(typeof(TestHandler));
+            handlers.Should().Contain(typeof(SecondTestHandler));
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // US1-d: Multiple AddLocalConsumer calls are additive
+        // ─────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task Multiple_AddLocalConsumer_calls_are_additive_Async()
+        {
+            var provider = BuildServices(m =>
+            {
+                m.AddLocalConsumer(c => c.Subscribe<TestEvent, TestHandler>());
+                m.AddLocalConsumer(c => c.Subscribe<OtherEvent, OtherHandler>());
+            });
+
+            var manager = provider.GetRequiredKeyedService<ISubscriptionsManager>("local");
+
+            var testHandlers = (await manager.GetHandlersForEventAsync(nameof(TestEvent))).ToList();
+            var otherHandlers = (await manager.GetHandlersForEventAsync(nameof(OtherEvent))).ToList();
+
+            testHandlers.Should().ContainSingle().Which.Should().Be(typeof(TestHandler));
+            otherHandlers.Should().ContainSingle().Which.Should().Be(typeof(OtherHandler));
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // US1-e: No handlers registered returns empty, not throws
+        // ─────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task No_handlers_registered_returns_empty_not_throws_Async()
+        {
+            var provider = BuildServices(m =>
+                m.AddLocalConsumer(_ => { /* no subscriptions */ }));
+
+            var manager = provider.GetRequiredKeyedService<ISubscriptionsManager>("local");
+
+            var act = async () =>
+                await manager.GetHandlersForEventAsync("UnknownEvent");
+
+            var result = await act.Should().NotThrowAsync();
+            result.Subject.Should().BeEmpty();
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // US1-f: Handler is registered as transient DI service
+        // ─────────────────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Subscribe_registers_handler_as_transient_di_service()
+        {
+            var provider = BuildServices(m =>
+                m.AddLocalConsumer(c => c.Subscribe<TestEvent, TestHandler>()));
+
+            var handler = provider.GetService<TestHandler>();
+
+            handler.Should().NotBeNull("handler must be resolvable from DI after Subscribe");
+        }
+
+        // ─── Supporting types ────────────────────────────────────────────────
+
+        private sealed record TestEvent : IntegrationEvent;
+        private sealed record OtherEvent : IntegrationEvent;
+
+        private sealed class TestHandler : IIntegrationEventHandler<TestEvent>
+        {
+            public Task HandleAsync(TestEvent @event) => Task.CompletedTask;
+        }
+
+        private sealed class SecondTestHandler : IIntegrationEventHandler<TestEvent>
+        {
+            public Task HandleAsync(TestEvent @event) => Task.CompletedTask;
+        }
+
+        private sealed class OtherHandler : IIntegrationEventHandler<OtherEvent>
+        {
+            public Task HandleAsync(OtherEvent @event) => Task.CompletedTask;
+        }
+    }
+}

--- a/core/test/Juice.Messaging.Local.Tests/LocalTransportPublisherTests.cs
+++ b/core/test/Juice.Messaging.Local.Tests/LocalTransportPublisherTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using FluentAssertions;
 using Juice.EventBus.Publishing;
+using Juice.EventBus.Subscriptions;
 using Juice.Messaging;
 using Juice.Messaging.Local.Internal;
 using Juice.XUnit;
@@ -263,6 +264,116 @@ namespace Juice.Messaging.Local.Tests
                 .WithMessage("*Type could not be resolved from headers*");
         }
 
+        // ─────────────────────────────────────────────────────────────────────
+        // US3-a: Handler registered via AddLocalConsumer is invoked by LocalTransportPublisher
+        // ─────────────────────────────────────────────────────────────────────
+
+        [IgnoreOnCIFact]
+        [InitializeMessageContext]
+        public async Task PublishAsync_dispatches_to_handler_registered_via_subscriptions_manager_Async()
+        {
+            var handled = new TaskCompletionSource<bool>();
+
+            var services = new ServiceCollection();
+            services.AddLogging(b => b.AddTestOutputLogger(_output));
+            var m = services.AddMessaging();
+            m.AddIdempotencyInMemory();
+            services.AddMediatR();
+
+            // Pre-register spy so TryAddTransient in Subscribe is a no-op
+            services.AddTransient<SubsManagerSpyHandler>(_ => new SubsManagerSpyHandler(handled));
+            m.AddLocalConsumer(c => c.Subscribe<TestIntegrationEvent, SubsManagerSpyHandler>());
+
+            var provider = services.BuildServiceProvider();
+            var scope = provider.CreateScope().ServiceProvider;
+            var publisher = ActivatorUtilities.CreateInstance<LocalTransportPublisher>(scope);
+            var serializer = scope.GetRequiredService<IMessageSerializer>();
+
+            var message = new TestIntegrationEvent();
+            var payload = serializer.SerializeToUtf8Bytes(message);
+            var context = new PublishContext(
+                message.MessageId.ToString(),
+                Headers: new Dictionary<string, object?> { ["x-message-type"] = nameof(TestIntegrationEvent) });
+
+            await publisher.PublishAsync(payload, context);
+
+            handled.Task.IsCompleted.Should().BeTrue("handler registered via AddLocalConsumer must be invoked by LocalTransportPublisher");
+            handled.Task.Result.Should().BeTrue();
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // US3-b: Handler in DI but not in subscriptions manager is NOT invoked
+        // ─────────────────────────────────────────────────────────────────────
+
+        [IgnoreOnCIFact]
+        [InitializeMessageContext]
+        public async Task PublishAsync_does_not_invoke_unregistered_handler_when_manager_present_Async()
+        {
+            var unregisteredInvoked = false;
+
+            var services = new ServiceCollection();
+            services.AddLogging(b => b.AddTestOutputLogger(_output));
+            var m = services.AddMessaging();
+            m.AddIdempotencyInMemory();
+            services.AddMediatR();
+
+            // Manager registered with no subscription for TestIntegrationEvent
+            m.AddLocalConsumer(_ => { });
+
+            // Register a handler only in DI — NOT via AddLocalConsumer
+            services.AddTransient<IIntegrationEventHandler<TestIntegrationEvent>>(
+                _ => new SideEffectHandler2(() => unregisteredInvoked = true));
+
+            var provider = services.BuildServiceProvider();
+            var scope = provider.CreateScope().ServiceProvider;
+            var publisher = ActivatorUtilities.CreateInstance<LocalTransportPublisher>(scope);
+            var serializer = scope.GetRequiredService<IMessageSerializer>();
+
+            var message = new TestIntegrationEvent();
+            var payload = serializer.SerializeToUtf8Bytes(message);
+            var context = new PublishContext(
+                message.MessageId.ToString(),
+                Headers: new Dictionary<string, object?> { ["x-message-type"] = nameof(TestIntegrationEvent) });
+
+            await publisher.PublishAsync(payload, context);
+
+            unregisteredInvoked.Should().BeFalse(
+                "handler registered only in DI must not be invoked when subscriptions manager is present");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // US3-c: Without AddLocalConsumer, DI-scan fallback still works
+        // ─────────────────────────────────────────────────────────────────────
+
+        [IgnoreOnCIFact]
+        [InitializeMessageContext]
+        public async Task PublishAsync_fallback_to_di_scan_when_no_manager_Async()
+        {
+            var handled = new TaskCompletionSource<bool>();
+
+            var provider = BuildServices(svc =>
+            {
+                // No AddLocalConsumer — DI scan fallback
+                svc.AddTransient<IIntegrationEventHandler<TestIntegrationEvent>>(
+                    _ => new SignalingHandler(handled));
+            });
+
+            var scope = provider.CreateScope().ServiceProvider;
+            var publisher = ActivatorUtilities.CreateInstance<LocalTransportPublisher>(scope);
+            var serializer = scope.GetRequiredService<IMessageSerializer>();
+
+            var message = new TestIntegrationEvent();
+            var payload = serializer.SerializeToUtf8Bytes(message);
+            var context = new PublishContext(
+                message.MessageId.ToString(),
+                Headers: new Dictionary<string, object?> { ["x-message-type"] = nameof(TestIntegrationEvent) });
+
+            await publisher.PublishAsync(payload, context);
+
+            handled.Task.IsCompleted.Should().BeTrue("DI-scan fallback must work when no subscriptions manager is registered");
+            handled.Task.Result.Should().BeTrue();
+        }
+
         // ─── Supporting types ────────────────────────────────────────────────
 
         private sealed record TestIntegrationEvent : IntegrationEvent;
@@ -297,6 +408,28 @@ namespace Juice.Messaging.Local.Tests
         {
             public Task HandleAsync(TestIntegrationEvent @event)
                 => throw new InvalidOperationException("Simulated handler failure");
+        }
+
+        /// <summary>Spy handler registered via <c>AddLocalConsumer</c> for US3 tests.</summary>
+        private sealed class SubsManagerSpyHandler(TaskCompletionSource<bool> signal)
+            : IIntegrationEventHandler<TestIntegrationEvent>
+        {
+            public Task HandleAsync(TestIntegrationEvent @event)
+            {
+                signal.TrySetResult(true);
+                return Task.CompletedTask;
+            }
+        }
+
+        /// <summary>Side-effect handler used to assert a handler is NOT invoked.</summary>
+        private sealed class SideEffectHandler2(Action onInvoke)
+            : IIntegrationEventHandler<TestIntegrationEvent>
+        {
+            public Task HandleAsync(TestIntegrationEvent @event)
+            {
+                onInvoke();
+                return Task.CompletedTask;
+            }
         }
     }
 }

--- a/specs/008-subscription-handler-lookup/checklists/requirements.md
+++ b/specs/008-subscription-handler-lookup/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Subscriptions Manager Handler Lookup for Local Routes
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/008-subscription-handler-lookup/contracts/public-api.md
+++ b/specs/008-subscription-handler-lookup/contracts/public-api.md
@@ -1,0 +1,105 @@
+# Public API Contracts: Subscriptions Manager Handler Lookup for Local Routes
+
+**Feature**: 008-subscription-handler-lookup
+**Date**: 2026-03-25
+**Library**: `Juice.Messaging.Local`
+
+---
+
+## New Public Types
+
+### `LocalConsumerBuilder`
+
+**Namespace**: `Juice.Messaging`
+**Assembly**: `Juice.Messaging.Local`
+
+```csharp
+public sealed class LocalConsumerBuilder
+{
+    // Registers THandler as a transient DI service and records the
+    // TEvent → THandler mapping in the subscriptions manager.
+    // key: optional override for the event routing key (defaults to TEvent.Name).
+    public LocalConsumerBuilder Subscribe<TEvent, THandler>(string? key = null)
+        where TEvent : IIntegrationEvent
+        where THandler : class, IIntegrationEventHandler<TEvent>;
+}
+```
+
+**Notes**:
+- Mirrors `RabbitMQConsumerBuilder.Subscribe<TEvent, THandler>()` API.
+- `Subscribe` is idempotent for the same `(TEvent, THandler, key)` triple.
+
+---
+
+## New Extension Methods
+
+### `MessagingBuilder.AddLocalConsumer`
+
+**Namespace**: `Juice.Messaging`
+**Assembly**: `Juice.Messaging.Local`
+
+```csharp
+public static class LocalMessagingBuilderExtensions
+{
+    // Registers the keyed ISubscriptionsManager (key = "local") for in-process routes
+    // and invokes configure to populate handler subscriptions.
+    // Safe to call multiple times — subsequent calls add to the existing manager.
+    public static MessagingBuilder AddLocalConsumer(
+        this MessagingBuilder builder,
+        Action<LocalConsumerBuilder> configure);
+}
+```
+
+**Behavior**:
+1. Creates a `LocalConsumerBuilder` backed by the current `IServiceCollection`.
+2. Calls `configure(builder)` to accumulate `SubscriptionInfo` records.
+3. Registers an `ISubscriptionsProvider` with the accumulated records.
+4. Ensures a keyed-singleton `ISubscriptionsManager` is registered under key `"local"`.
+5. When the host resolves `ISubscriptionsManager` (key `"local"`) for the first time, `InMemorySubscriptionsManager` reads all registered `ISubscriptionsProvider` instances and populates itself.
+
+---
+
+## Changed Behavior (No Interface Changes)
+
+### `LocalDispatchHelper.DispatchIntegrationEventAsync` *(internal)*
+
+```csharp
+// BEFORE (current):
+internal static Task<EventDispatchResult> DispatchIntegrationEventAsync(
+    IServiceProvider serviceProvider,
+    IntegrationEventDispatcher dispatcher,
+    IIntegrationEvent evt,
+    CancellationToken cancellationToken);
+
+// AFTER:
+internal static Task<EventDispatchResult> DispatchIntegrationEventAsync(
+    IServiceProvider serviceProvider,
+    IntegrationEventDispatcher dispatcher,
+    ISubscriptionsManager? subscriptionsManager,   // NEW — nullable
+    IIntegrationEvent evt,
+    CancellationToken cancellationToken);
+```
+
+**Dispatch logic**:
+- If `subscriptionsManager` is non-null: call `GetHandlersForEventAsync(evt.GetType().Name)` to get handler types.
+- If `subscriptionsManager` is null: fall back to `serviceProvider.GetServices(IIntegrationEventHandler<T>)` (existing behavior, backward compatible).
+
+### `LocalChannelBackgroundService` *(internal)*
+
+- Injects `[FromKeyedServices("local")] ISubscriptionsManager? subscriptionsManager` (nullable — optional).
+- Passes it to `LocalDispatchHelper.DispatchIntegrationEventAsync`.
+
+### `LocalTransportPublisher` *(internal)*
+
+- Injects `[FromKeyedServices("local")] ISubscriptionsManager? subscriptionsManager` (nullable — optional).
+- Passes it to `LocalDispatchHelper.DispatchIntegrationEventAsync`.
+
+---
+
+## No Changes To
+
+- `ISubscriptionsManager` interface — unchanged.
+- `SubscriptionInfo`, `ISubscriptionsProvider`, `InMemorySubscriptionsManager` — unchanged.
+- `IIntegrationEventHandler<T>` — unchanged.
+- RabbitMQ consumer registration and dispatch paths — unchanged.
+- `IntegrationEventDispatcher` — unchanged.

--- a/specs/008-subscription-handler-lookup/data-model.md
+++ b/specs/008-subscription-handler-lookup/data-model.md
@@ -1,0 +1,82 @@
+# Data Model: Subscriptions Manager Handler Lookup for Local Routes
+
+**Feature**: 008-subscription-handler-lookup
+**Date**: 2026-03-25
+
+> This feature does not introduce new persistent entities (no database tables, no migrations).
+> All data is held in-memory within the `ISubscriptionsManager` singleton for the lifetime of the host process.
+
+---
+
+## Runtime Entities
+
+### SubscriptionInfo *(existing — no changes)*
+
+Represents a single (event type → handler type) binding, keyed by a routing key string.
+
+| Field        | Type     | Notes                                                     |
+|--------------|----------|-----------------------------------------------------------|
+| `EventType`  | `Type`   | The CLR type implementing `IIntegrationEvent`             |
+| `HandlerType`| `Type`   | The CLR type implementing `IIntegrationEventHandler<T>`   |
+| `Key`        | `string` | Routing/event-name key; defaults to `EventType.Name`     |
+| `IsDynamic`  | `bool`   | Always `false` for local-route subscriptions              |
+
+**Used by**: `ISubscriptionsManager.AddSubscription`, `ISubscriptionsManager.GetHandlersForEventAsync`
+
+---
+
+### ISubscriptionsManager — local instance *(keyed "local")*
+
+A singleton `InMemorySubscriptionsManager` registered under DI key `"local"`. Populated at construction time from `ISubscriptionsProvider` instances gathered by `LocalConsumerBuilder`.
+
+| Attribute            | Value                                       |
+|----------------------|---------------------------------------------|
+| DI lifetime          | Singleton                                   |
+| DI key               | `"local"`                                   |
+| topic support        | `false` (exact-name match only)             |
+| Populated by         | `LocalConsumerBuilder` → `ISubscriptionsProvider` |
+| Queried by           | `LocalDispatchHelper` (when non-null)       |
+
+---
+
+### LocalConsumerBuilder *(new)*
+
+A transient builder object created during DI setup (i.e., within `AddLocalConsumer(...)`). Accumulates `SubscriptionInfo` records and registers handler types in `IServiceCollection`.
+
+| Field          | Type                       | Notes                                           |
+|----------------|----------------------------|-------------------------------------------------|
+| `_services`    | `IServiceCollection`       | The host service collection                     |
+| `_subscriptions`| `List<SubscriptionInfo>` | Accumulated registrations                        |
+
+**Methods**:
+- `Subscribe<TEvent, THandler>(string? key = null)` — adds `SubscriptionInfo` + `services.TryAddTransient<THandler>()`
+- `Build()` → `ISubscriptionsProvider` — produces the provider that feeds `InMemorySubscriptionsManager`
+
+---
+
+## State Transitions (dispatch flow)
+
+```
+AddLocalConsumer(builder => builder.Subscribe<TEvent, THandler>())
+    │
+    ▼
+LocalConsumerBuilder.Build() → InMemorySubscriptionsProvider
+    │
+    ▼
+InMemorySubscriptionsManager("local") ← constructed at first DI resolve
+    │
+    ▼  (at dispatch time)
+LocalDispatchHelper.DispatchIntegrationEventAsync(sp, dispatcher, subsManager, evt, ct)
+    │
+    ├── subsManager != null → subsManager.GetHandlersForEventAsync(evt.GetType().Name)
+    │                             → List<Type> handlerTypes
+    │
+    └── subsManager == null → serviceProvider.GetServices(IIntegrationEventHandler<T>)
+                                  → List<Type> handlerTypes (DI scan fallback)
+    │
+    ▼
+IntegrationEventDispatcher.DispatchAsync(evt, EventDispatchContext(handlerTypes, ...))
+    │
+    ▼
+Handler invoked per handlerType (resolved from scoped DI within dispatcher)
+```

--- a/specs/008-subscription-handler-lookup/plan.md
+++ b/specs/008-subscription-handler-lookup/plan.md
@@ -1,0 +1,212 @@
+# Implementation Plan: Subscriptions Manager Handler Lookup for Local Routes
+
+**Branch**: `008-subscription-handler-lookup` | **Date**: 2026-03-25 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/008-subscription-handler-lookup/spec.md`
+
+## Summary
+
+Extend `Juice.Messaging.Local` so that `ISubscriptionsManager` (already used by RabbitMQ consumers) is also used to register and resolve handlers for integration events published on the `"local"` and `"local-channel"` in-process routes. A new `LocalConsumerBuilder` and `AddLocalConsumer` extension method on `MessagingBuilder` provide the registration API. When the subscriptions manager is populated, `LocalDispatchHelper` uses it instead of scanning DI; when it is absent the existing DI-scan fallback preserves backward compatibility.
+
+---
+
+## Technical Context
+
+**Language/Version**: C# / .NET 6, 8, 9 (multi-target `net6.0;net8.0;net9.0`)
+**Primary Dependencies**: `Juice.EventBus` (ISubscriptionsManager, SubscriptionInfo, ISubscriptionsProvider, InMemorySubscriptionsManager), `Juice.Messaging.Local` (LocalDispatchHelper, LocalChannelBackgroundService, LocalTransportPublisher, LocalMessagingBuilderExtensions)
+**Storage**: N/A — runtime in-memory singleton; no DB migration required
+**Testing**: xUnit, `IgnoreOnCIFact` for infra tests; `[InitializeMessageContext]` on messaging test classes
+**Target Platform**: Any .NET host (ASP.NET Core, Worker Service, console)
+**Project Type**: NuGet library (`Juice.Messaging.Local`)
+**Performance Goals**: No measurable overhead — `ISubscriptionsManager.GetHandlersForEventAsync` is an in-memory dictionary lookup
+**Constraints**: No breaking changes to `ISubscriptionsManager` interface; no changes to RabbitMQ paths; keyed DI must work across all target frameworks
+**Scale/Scope**: Single library project, ~5 files modified/added, ~2 test classes
+
+---
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Lightweight & Dual-Architecture | ✅ PASS | Feature is opt-in via `AddLocalConsumer`; no forced dependency on subscriptions manager. Fallback keeps monolith/microservice parity. |
+| II. Library-First Composability | ✅ PASS | All changes in `Juice.Messaging.Local` (`core/src/`). No new project required — `LocalConsumerBuilder` is a natural addition to the existing library. No new cross-library dependency. |
+| III. DDD + CQRS | ✅ PASS | No business logic changes. No pipeline behavior changes. |
+| IV. Reliable Messaging via Outbox | ✅ PASS | Outbox write path unchanged. `LocalTransportPublisher` dispatch logic extended (handler lookup only), not bypassed. |
+| V. Multi-Tenancy First | ✅ PASS | `ISubscriptionsManager.GetHandlersForEventAsync` returns handler types; `IntegrationEventDispatcher` already passes `TenantId` from the event — no change needed. |
+
+**Post-Design Re-check**: ✅ All principles pass. No violations to justify.
+
+---
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-subscription-handler-lookup/
+├── plan.md              ← this file
+├── spec.md              ← feature specification
+├── research.md          ← Phase 0: all key decisions
+├── data-model.md        ← Phase 1: runtime entities & dispatch flow
+├── quickstart.md        ← Phase 1: usage guide
+├── contracts/
+│   └── public-api.md    ← Phase 1: new types & changed signatures
+└── checklists/
+    └── requirements.md  ← spec quality checklist
+```
+
+### Source Code (repository root)
+
+```text
+core/src/Juice.Messaging.Local/
+├── DependencyInjection/
+│   └── LocalMessagingBuilderExtensions.cs   ← ADD AddLocalConsumer() method
+├── Internal/
+│   ├── LocalConsumerBuilder.cs              ← NEW
+│   ├── LocalDispatchHelper.cs               ← MODIFY: add ISubscriptionsManager? param
+│   ├── LocalChannelBackgroundService.cs     ← MODIFY: inject & pass ISubscriptionsManager
+│   └── LocalTransportPublisher.cs           ← MODIFY: inject & pass ISubscriptionsManager
+
+core/test/Juice.Messaging.Local.Tests/       ← NEW test project (or extend existing)
+├── LocalConsumerBuilderTests.cs             ← unit tests
+└── LocalChannelDispatchTests.cs             ← integration tests (no infra needed)
+```
+
+**Existing files not changed**:
+- `Juice.EventBus/Subscriptions/ISubscriptionsManager.cs`
+- `Juice.EventBus/Subscriptions/InMemorySubscriptionsManager.cs`
+- `Juice.EventBus/Subscriptions/SubscriptionInfo.cs`
+- `Juice.EventBus/Subscriptions/ISubscriptionsProvider.cs`
+- `Juice.EventBus/Subscriptions/InMemorySubscriptionsProvider.cs`
+- `Juice.EventBus.RabbitMQ/**` (all RabbitMQ files)
+- `Juice.Messaging/Integrations/IntegrationEventDispatcher.cs`
+
+**Structure Decision**: Single library project `Juice.Messaging.Local`. No new library project justified — the feature adds a builder class and modifies three internal classes within existing project boundaries.
+
+---
+
+## Implementation Steps
+
+### Step 1 — `LocalConsumerBuilder` (new internal class)
+
+**File**: `core/src/Juice.Messaging.Local/Internal/LocalConsumerBuilder.cs`
+
+- Accumulates `SubscriptionInfo` records via `Subscribe<TEvent, THandler>(string? key = null)`.
+- Calls `services.TryAddTransient<THandler>()` for each handler.
+- `Build()` returns an `InMemorySubscriptionsProvider` wrapping the accumulated list.
+- Make it `internal sealed` (only created inside `AddLocalConsumer`).
+
+### Step 2 — `AddLocalConsumer` extension method
+
+**File**: `core/src/Juice.Messaging.Local/DependencyInjection/LocalMessagingBuilderExtensions.cs`
+
+- New `AddLocalConsumer(this MessagingBuilder builder, Action<LocalConsumerBuilder> configure)` method.
+- Creates `LocalConsumerBuilder`, calls `configure`, calls `Build()` to get an `ISubscriptionsProvider`.
+- Registers the provider with `services.AddSingleton<ISubscriptionsProvider>(provider)`.
+- Ensures keyed singleton `ISubscriptionsManager` under key `"local"`:
+  ```
+  services.TryAddKeyedSingleton<ISubscriptionsManager>("local", (sp, _) =>
+      new InMemorySubscriptionsManager(
+          sp.GetServices<ISubscriptionsProvider>(),
+          sp.GetRequiredService<ILogger<InMemorySubscriptionsManager>>(),
+          topicSupport: false));
+  ```
+  Use `TryAdd` to prevent double-registration if `AddLocalConsumer` is called more than once. Note: multiple calls to `AddLocalConsumer` each register an `ISubscriptionsProvider`; the singleton manager picks up all of them because `InMemorySubscriptionsManager` accepts `IEnumerable<ISubscriptionsProvider>`.
+
+### Step 3 — Modify `LocalDispatchHelper`
+
+**File**: `core/src/Juice.Messaging.Local/Internal/LocalDispatchHelper.cs`
+
+Change `DispatchIntegrationEventAsync` signature to accept `ISubscriptionsManager? subscriptionsManager`:
+
+```csharp
+public static async Task<EventDispatchResult> DispatchIntegrationEventAsync(
+    IServiceProvider serviceProvider,
+    IntegrationEventDispatcher dispatcher,
+    ISubscriptionsManager? subscriptionsManager,   // NEW
+    IIntegrationEvent evt,
+    CancellationToken cancellationToken)
+{
+    List<Type> handlerTypes;
+
+    if (subscriptionsManager != null)
+    {
+        var types = await subscriptionsManager.GetHandlersForEventAsync(evt.GetType().Name);
+        handlerTypes = types.ToList();
+    }
+    else
+    {
+        // Backward-compatible fallback: open DI scan
+        var handlerType = typeof(IIntegrationEventHandler<>).MakeGenericType(evt.GetType());
+        handlerTypes = serviceProvider.GetServices(handlerType)
+            .Select(h => h!.GetType()).ToList();
+    }
+
+    var source = MessageContext.IsInitialized
+        ? MessageContext.Current.Source ?? string.Empty
+        : string.Empty;
+
+    var context = new EventDispatchContext(
+        handlerTypes, evt.GetType().Name, evt.TenantId, source);
+
+    return await dispatcher.DispatchAsync(evt, context);
+}
+```
+
+### Step 4 — Modify `LocalChannelBackgroundService`
+
+**File**: `core/src/Juice.Messaging.Local/Internal/LocalChannelBackgroundService.cs`
+
+- Add constructor parameter `[FromKeyedServices("local")] ISubscriptionsManager? subscriptionsManager = null`.
+- Store in `_subscriptionsManager` field.
+- Pass `_subscriptionsManager` to `LocalDispatchHelper.DispatchIntegrationEventAsync(...)`.
+
+### Step 5 — Modify `LocalTransportPublisher`
+
+**File**: `core/src/Juice.Messaging.Local/Internal/LocalTransportPublisher.cs`
+
+- Add constructor parameter `[FromKeyedServices("local")] ISubscriptionsManager? subscriptionsManager = null`.
+- Store in `_subscriptionsManager` field.
+- Pass `_subscriptionsManager` to `LocalDispatchHelper.DispatchIntegrationEventAsync(...)`.
+
+### Step 6 — Tests
+
+**File**: `core/test/Juice.Messaging.Local.Tests/LocalConsumerBuilderTests.cs`
+
+Unit tests (no external infra):
+1. `Subscribe_registers_handler_in_subscriptions_manager_Async` — verify `GetHandlersForEventAsync` returns the registered type after `AddLocalConsumer`.
+2. `Subscribe_is_idempotent_for_same_event_handler_pair_Async` — duplicate call does not double-register.
+3. `Multiple_handlers_for_same_event_are_all_returned_Async` — two handlers, both returned.
+
+**File**: `core/test/Juice.Messaging.Local.Tests/LocalChannelDispatchTests.cs`
+
+Integration tests (in-memory, no RabbitMQ/DB needed):
+1. `Local_channel_dispatches_to_registered_handler_via_subscriptions_manager_Async` — publish on local-channel, verify handler invoked.
+2. `Local_channel_does_not_invoke_unregistered_handler_Async` — handler in DI but not in subscriptions manager → not invoked.
+3. `Local_channel_fallback_to_di_scan_when_no_subscriptions_manager_Async` — without `AddLocalConsumer`, existing DI-scan behavior is preserved.
+4. `Dispatch_result_is_not_handled_when_no_handlers_registered_Async` — no handlers in manager → result is `NotHandled`.
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| `InMemorySubscriptionsManager` internal constructor not accessible from `Juice.Messaging.Local` | Low | High | Both projects are in same solution; use `InternalsVisibleTo` or make constructor internal + visible, matching the existing pattern in `Juice.EventBus` |
+| Multiple `AddLocalConsumer` calls create multiple `ISubscriptionsProvider` — manager sees all or only first | Low | Medium | `IEnumerable<ISubscriptionsProvider>` in constructor; all providers are collected — multiple calls are additive. Covered by test. |
+| Keyed nullable DI injection (`[FromKeyedServices("local")] ISubscriptionsManager? = null`) not supported on target frameworks | Low | Medium | Nullable keyed services are supported in .NET 8+ via `GetKeyedService<T>()`. For net6 targets, use `serviceProvider.GetKeyedService<ISubscriptionsManager>("local")` resolution pattern instead of constructor injection, or guard with try-catch. |
+
+---
+
+## Definition of Done
+
+- [ ] `LocalConsumerBuilder` created in `Juice.Messaging.Local`.
+- [ ] `AddLocalConsumer` extension registered and tested.
+- [ ] `LocalDispatchHelper` modified with `ISubscriptionsManager?` parameter.
+- [ ] `LocalChannelBackgroundService` injects and passes subscriptions manager.
+- [ ] `LocalTransportPublisher` injects and passes subscriptions manager.
+- [ ] All new unit tests pass without external infra.
+- [ ] Fallback (no `AddLocalConsumer`) behavior verified by test.
+- [ ] No existing tests broken.
+- [ ] No breaking change to `ISubscriptionsManager` public interface.

--- a/specs/008-subscription-handler-lookup/quickstart.md
+++ b/specs/008-subscription-handler-lookup/quickstart.md
@@ -1,0 +1,135 @@
+# Quickstart: Subscriptions Manager Handler Lookup for Local Routes
+
+**Feature**: 008-subscription-handler-lookup
+
+---
+
+## Before (existing behavior)
+
+Handlers registered in DI are discovered automatically at dispatch time via a container scan. No explicit subscription registration is required.
+
+```csharp
+// Program.cs — existing approach
+services.AddMessaging(messaging =>
+{
+    messaging.AddLocalChannel();
+    messaging.AddLocalPublisher();
+});
+
+// Handler registration — implicit discovery
+services.AddTransient<IIntegrationEventHandler<OrderCreatedEvent>, OrderCreatedHandler>();
+```
+
+With the existing approach, **every** `IIntegrationEventHandler<OrderCreatedEvent>` in the DI container is invoked when an `OrderCreatedEvent` arrives — even handlers added by other library packages, test doubles, etc.
+
+---
+
+## After (with explicit subscription registry)
+
+Use `AddLocalConsumer` to register handlers explicitly. The subscriptions manager then controls exactly which handlers are invoked.
+
+```csharp
+// Program.cs — new explicit approach
+services.AddMessaging(messaging =>
+{
+    messaging.AddLocalChannel();     // "local-channel" route
+    messaging.AddLocalPublisher();   // "local" outbox-backed route
+
+    // Register handlers for local routes via the subscriptions manager
+    messaging.AddLocalConsumer(consumer =>
+    {
+        consumer.Subscribe<OrderCreatedEvent, OrderCreatedHandler>();
+        consumer.Subscribe<OrderShippedEvent, OrderShippedHandler>();
+    });
+});
+```
+
+This registers:
+1. `OrderCreatedHandler` and `OrderShippedHandler` as transient DI services.
+2. A keyed `ISubscriptionsManager` (key `"local"`) containing the two subscriptions.
+
+When `OrderCreatedEvent` arrives on `"local-channel"` or `"local"`, only `OrderCreatedHandler` is invoked — exactly as registered.
+
+---
+
+## Multiple handler registrations for the same event
+
+```csharp
+messaging.AddLocalConsumer(consumer =>
+{
+    consumer.Subscribe<OrderCreatedEvent, EmailNotificationHandler>();
+    consumer.Subscribe<OrderCreatedEvent, AuditLogHandler>();
+});
+```
+
+Both handlers are invoked in registration order when `OrderCreatedEvent` is dispatched.
+
+---
+
+## Custom routing key
+
+Use a routing key override when the event name alone is not a sufficient discriminator.
+
+```csharp
+messaging.AddLocalConsumer(consumer =>
+{
+    consumer.Subscribe<OrderCreatedEvent, OrderCreatedHandler>(key: "orders.created");
+});
+```
+
+The dispatcher will look up handlers by the key `"orders.created"` instead of the default `"OrderCreatedEvent"`.
+
+---
+
+## Querying the registry (introspection)
+
+```csharp
+// Inject ISubscriptionsManager for the "local" key
+public class DiagnosticsService(
+    [FromKeyedServices("local")] ISubscriptionsManager subscriptionsManager)
+{
+    public async Task<IEnumerable<Type>> GetHandlersAsync(string eventName)
+        => await subscriptionsManager.GetHandlersForEventAsync(eventName);
+}
+```
+
+---
+
+## Backward compatibility
+
+If `AddLocalConsumer` is never called, local-channel and local routes continue to discover handlers via the DI container scan (existing behavior). No changes to existing code are required to maintain the pre-feature behavior.
+
+---
+
+## Testing
+
+```csharp
+[Collection("LocalChannel")]
+[InitializeMessageContext]
+public class OrderCreatedDispatchTests
+{
+    [Fact]
+    public async Task Should_invoke_registered_handler_via_subscriptions_manager_Async()
+    {
+        // Arrange: build host with AddLocalConsumer
+        var host = Host.CreateDefaultBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddMessaging(m =>
+                {
+                    m.AddLocalChannel();
+                    m.AddLocalConsumer(c =>
+                        c.Subscribe<OrderCreatedEvent, OrderCreatedHandler>());
+                });
+            })
+            .Build();
+
+        // Act: publish event on local-channel
+        var publisher = host.Services.GetRequiredKeyedService<IMessagePublisher>("local-channel");
+        await publisher.PublishAsync(new OrderCreatedEvent { OrderId = "42" });
+
+        // Assert: handler invocation verified via test double / spy
+        // ...
+    }
+}
+```

--- a/specs/008-subscription-handler-lookup/research.md
+++ b/specs/008-subscription-handler-lookup/research.md
@@ -1,0 +1,77 @@
+# Research: Subscriptions Manager Handler Lookup for Local Routes
+
+**Feature**: 008-subscription-handler-lookup
+**Date**: 2026-03-25
+
+---
+
+## Decision 1: Shared or separate subscriptions manager for local routes?
+
+**Decision**: One shared `ISubscriptionsManager` singleton, keyed `"local"`, serves both `"local"` and `"local-channel"` routes.
+
+**Rationale**: Both routes dispatch to the same in-process handlers. There is no use case where the same event type would need different handlers on local vs local-channel for the same application instance. A single registry is simpler and avoids duplication. Parity with RabbitMQ (which uses a keyed singleton per consumer) is maintained by using the same keyed DI pattern with the well-known key `"local"`.
+
+**Alternatives considered**:
+- *Separate managers per route* — unnecessary complexity; the spec has one subscription registry for both routes.
+- *Unkeyed singleton* — conflicts with future extensions and is harder to distinguish from RabbitMQ managers in DI diagnostics.
+- *Non-keyed interface extension* — would require adding a new interface `ILocalSubscriptionsManager`, which violates YAGNI (the existing `ISubscriptionsManager` covers all needed operations).
+
+---
+
+## Decision 2: Replace DI scan or augment it?
+
+**Decision**: Replace the DI scan with the subscriptions manager when it is registered. Fall back to the existing DI scan when no subscriptions manager is registered (i.e., `AddLocalConsumer` was never called).
+
+**Rationale**: The spec requires that only explicitly registered handlers are invoked (SC-002). Replacing the DI scan achieves this. The fallback to DI scan when no manager exists preserves backward compatibility for applications that do not yet call `AddLocalConsumer` — they keep the current open-discovery behavior unchanged.
+
+**Alternatives considered**:
+- *Always replace, no fallback* — breaks all existing local-route consumers on upgrade; violates Lightweight principle (forces every app to add `AddLocalConsumer` calls).
+- *Always augment (union of both)* — violates SC-002 ("no unregistered handler is invoked"); creates surprising behavior.
+- *Feature flag to opt-in* — unnecessary complexity; presence of the keyed `ISubscriptionsManager` is a sufficient signal.
+
+---
+
+## Decision 3: Where is `ISubscriptionsManager` registered for local routes?
+
+**Decision**: Registered in `AddLocalConsumer(Action<LocalConsumerBuilder>)` on `MessagingBuilder`, as a keyed singleton under key `"local"`. Uses the existing `InMemorySubscriptionsManager` with an `ISubscriptionsProvider` populated by `LocalConsumerBuilder`.
+
+**Rationale**: Mirrors the `RabbitMQConsumerBuilder` pattern exactly — `SubscriptionBuilder` gathers `SubscriptionInfo` records; `InMemorySubscriptionsProvider` adapts them; `InMemorySubscriptionsManager` consumes the provider. No new abstractions required. Re-uses `topicSupport: false` (exact-name matching only for local routes, as scoped in the spec's Assumptions).
+
+**Alternatives considered**:
+- *New `ILocalSubscriptionsProvider` subtype* — unnecessary; `ISubscriptionsProvider` is already generic enough.
+- *Direct `AddSubscription` calls at startup via `IHostedService`* — imperative, harder to test in isolation.
+
+---
+
+## Decision 4: How does `LocalDispatchHelper` receive the subscriptions manager?
+
+**Decision**: `LocalDispatchHelper.DispatchIntegrationEventAsync` gains an `ISubscriptionsManager?` parameter. Callers (`LocalChannelBackgroundService`, `LocalTransportPublisher`) inject the keyed `ISubscriptionsManager` with key `"local"` and pass it through. If the resolved service is `null` (not registered), the helper falls back to DI scan.
+
+**Rationale**: `LocalDispatchHelper` is an `internal static` class — it has no DI injection. Passing the manager as a parameter keeps the helper stateless and directly testable. `LocalChannelBackgroundService` and `LocalTransportPublisher` both already inject services from DI; adding one more keyed injection is minimal.
+
+**Alternatives considered**:
+- *Make `LocalDispatchHelper` non-static and inject `ISubscriptionsManager`* — heavier refactor than needed; the static pattern is idiomatic in this codebase.
+- *Resolve from `IServiceProvider` inside the helper* — hides the dependency, harder to test.
+
+---
+
+## Decision 5: Builder API design — `LocalConsumerBuilder`
+
+**Decision**: New `LocalConsumerBuilder` class in `Juice.Messaging.Local`, mirroring `RabbitMQConsumerBuilder`. Exposes `Subscribe<TEvent, THandler>(string? key = null)` which (a) adds a `SubscriptionInfo` and (b) registers `THandler` as transient in DI.
+
+**Rationale**: Consistent API across all consumer routes. Developers already familiar with `RabbitMQConsumerBuilder.Subscribe<>()` will find the same pattern here. Single method call handles both subscription registry AND DI registration.
+
+**Alternatives considered**:
+- *Extend `MessagingBuilder` with `SubscribeLocal<TEvent, THandler>()`* — flat, no builder nesting; harder to group related subscriptions.
+- *Reuse `SubscriptionBuilder` directly* — `SubscriptionBuilder` doesn't register handlers in DI; a thin wrapper would still be needed.
+
+---
+
+## Decision 6: Breaking-change scope
+
+**Decision**: This is a behavioral change (not an interface-breaking change) for applications that call `AddLocalConsumer`. The `ISubscriptionsManager` interface is unchanged. `LocalDispatchHelper`'s signature changes, but it is `internal`.
+
+**Rationale**: No public API surface changes. Existing applications that don't call `AddLocalConsumer` are unaffected (fallback to DI scan). Applications that do call `AddLocalConsumer` get the new explicit-registration behavior. No MAJOR version bump required for the library itself (behavior opt-in, not forced).
+
+**Alternatives considered**:
+- *Force MAJOR bump* — overly disruptive; the change is opt-in via the new builder method.

--- a/specs/008-subscription-handler-lookup/spec.md
+++ b/specs/008-subscription-handler-lookup/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: Subscriptions Manager Handler Lookup for Local Routes
+
+**Feature Branch**: `008-subscription-handler-lookup`
+**Created**: 2026-03-25
+**Status**: Draft
+**Input**: User description: "use subscriptions manager to get handler for integration event that published via local/local-channel"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Register Local Handler via Subscriptions Manager (Priority: P1)
+
+A developer building a Juice-based service registers an integration event handler for local or local-channel delivery. Today the subscriptions manager is unaware of these registrations; the developer has no unified way to query which handlers are active for an event type without knowing which route was used. With this feature, when a handler is registered for a local or local-channel route, it is also recorded in the subscriptions manager, giving developers one place to inspect all active handler subscriptions.
+
+**Why this priority**: Foundational prerequisite — the subscriptions manager must be populated before it can be queried. Without this, all other stories have nothing to look up.
+
+**Independent Test**: Register `MyEventHandler` for local-channel route. Call `ISubscriptionsManager.GetHandlersForEventAsync("MyEvent")`. Verify `MyEventHandler` is returned. This alone proves the registry is being populated and delivers value as a discoverability/introspection tool.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer registers a handler `IIntegrationEventHandler<TEvent>` for the `"local-channel"` route, **When** `ISubscriptionsManager.GetHandlersForEventAsync(eventName)` is called, **Then** the handler type is included in the returned collection.
+2. **Given** a developer registers a handler for the `"local"` (outbox-backed) route, **When** `ISubscriptionsManager.GetHandlersForEventAsync(eventName)` is called, **Then** the handler type is included in the returned collection.
+3. **Given** a handler is registered for both RabbitMQ and local-channel routes, **When** the subscriptions manager is queried, **Then** both route registrations are represented without duplicates.
+
+---
+
+### User Story 2 — Dispatch via Subscriptions Manager on Local-Channel Route (Priority: P2)
+
+A developer publishes an integration event on the `"local-channel"` route. Currently, the dispatcher discovers handlers by scanning the DI container for `IIntegrationEventHandler<T>` at dispatch time. With this feature, the dispatcher first consults the subscriptions manager to determine which handlers should be invoked. This makes handler resolution explicit and auditable, consistent with how RabbitMQ consumers already work.
+
+**Why this priority**: Closes the behavioral gap between broker and local routes. Enables the subscriptions manager to be the authoritative source for handler lookup across all routes.
+
+**Independent Test**: Register one handler via the subscriptions manager for a local-channel route, publish an event, and verify the handler is invoked. Separately verify that a handler NOT registered in the subscriptions manager (but still in DI) is not invoked if the subscriptions manager is the sole lookup source.
+
+**Acceptance Scenarios**:
+
+1. **Given** a handler is registered in the subscriptions manager for a `"local-channel"` event, **When** an event of that type is published on `"local-channel"`, **Then** the handler is invoked exactly once.
+2. **Given** no handler is registered in the subscriptions manager for an event type, **When** that event is published on `"local-channel"`, **Then** the dispatch result is `NotHandled` and no error is raised.
+3. **Given** multiple handlers are registered for the same event type, **When** the event is published, **Then** all registered handlers are invoked.
+
+---
+
+### User Story 3 — Dispatch via Subscriptions Manager on Local (Outbox-Backed) Route (Priority: P3)
+
+A developer publishes an integration event on the `"local"` route (outbox-backed, durable delivery). With this feature, when the delivery service processes the outbox record, it consults the subscriptions manager to resolve handlers — consistent with how `"local-channel"` and RabbitMQ routes work after this feature is implemented.
+
+**Why this priority**: Completes parity across all three delivery routes. Lower priority because `"local"` delivery is already functional via DI discovery; this story brings consistency rather than new capability.
+
+**Independent Test**: Register a handler for the local route, publish an event, allow the delivery service to process the outbox record, and verify the handler was invoked using handlers resolved from the subscriptions manager.
+
+**Acceptance Scenarios**:
+
+1. **Given** a handler is registered in the subscriptions manager for a `"local"` event, **When** the delivery service processes the corresponding outbox record, **Then** the handler is invoked exactly once.
+2. **Given** idempotency is active and the same outbox record is processed twice, **When** handlers are resolved via the subscriptions manager, **Then** only the first delivery invokes the handler; the second returns `Duplicated`.
+
+---
+
+### Edge Cases
+
+- What happens when a handler is registered in DI but NOT registered with the subscriptions manager? After this feature, only subscriptions-manager-registered handlers should be invoked for local/local-channel routes.
+- What happens when the subscriptions manager is queried for an event type that has never been registered? It must return an empty collection, not throw.
+- What happens when `GetHandlersForEventAsync` is called with a routing key that uses topic wildcards? Behavior for local routes with wildcard keys should be defined (either unsupported or explicitly supported).
+- What happens when the same handler type is registered twice for the same event? The subscriptions manager must deduplicate and invoke the handler only once.
+- What happens when a handler is registered but its DI registration has been removed? The dispatcher must handle the missing DI entry gracefully (skip with a warning, not throw).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The subscriptions manager MUST support registering handler types for events on the `"local-channel"` route.
+- **FR-002**: The subscriptions manager MUST support registering handler types for events on the `"local"` (outbox-backed) route.
+- **FR-003**: The local-channel dispatcher MUST consult the subscriptions manager to retrieve handler types when processing a received event, instead of performing an unscoped DI scan.
+- **FR-004**: The local (outbox-backed) delivery path MUST consult the subscriptions manager to retrieve handler types when processing an outbox record.
+- **FR-005**: The subscriptions manager MUST return an empty collection (not throw) when no handlers are registered for a given event name.
+- **FR-006**: Registration of the same handler type for the same event MUST be idempotent — duplicate registrations must not cause the handler to be invoked multiple times.
+- **FR-007**: The existing RabbitMQ subscription registration and lookup behavior MUST remain unchanged.
+- **FR-008**: The builder/configuration API for registering local and local-channel handlers MUST automatically populate the subscriptions manager as part of the same registration call.
+- **FR-009**: The subscriptions manager MUST allow querying all registered event names for a given route (local, local-channel, or all), to support introspection and diagnostics.
+
+### Key Entities
+
+- **Subscription**: A record pairing an event type name with a handler type, scoped to a delivery route (`"local"`, `"local-channel"`, or `"broker"`). Key attributes: event name, handler type, route key.
+- **ISubscriptionsManager**: The central registry interface that stores and retrieves subscriptions. Extended to support local-route registrations alongside existing broker registrations.
+- **EventDispatchContext**: The object passed to `IntegrationEventDispatcher` containing the list of handler types to invoke. Must be populated from subscriptions manager results for local routes.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Developers can determine all registered handlers for any event type, across all routes, through a single query to the subscriptions manager — without inspecting DI registrations or source code.
+- **SC-002**: An integration event published on `"local-channel"` is dispatched only to handlers explicitly registered in the subscriptions manager; no unregistered handler is invoked as a side effect.
+- **SC-003**: An integration event published on `"local"` route is dispatched only to handlers explicitly registered in the subscriptions manager; no unregistered handler is invoked as a side effect.
+- **SC-004**: Handler lookup and dispatch behavior for `"local"` and `"local-channel"` routes is verified by automated tests that pass without requiring external infrastructure (no RabbitMQ, no database needed for `"local-channel"` tests).
+- **SC-005**: No existing passing tests for RabbitMQ or outbox delivery regress after this change.
+
+## Assumptions
+
+- The subscriptions manager is populated at application startup via the DI builder API; dynamic registration at runtime is out of scope.
+- Topic/wildcard routing key support for local routes is deferred — this feature covers exact event-name matching only.
+- The route key (`"local"`, `"local-channel"`) is stored alongside each subscription to allow route-specific handler queries.
+- Handler types registered for local routes are assumed to be resolvable from the DI container; the dispatcher gracefully skips types that cannot be resolved.

--- a/specs/008-subscription-handler-lookup/tasks.md
+++ b/specs/008-subscription-handler-lookup/tasks.md
@@ -1,0 +1,198 @@
+# Tasks: Subscriptions Manager Handler Lookup for Local Routes
+
+**Input**: Design documents from `/specs/008-subscription-handler-lookup/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/public-api.md ✅, quickstart.md ✅
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Paths are relative to repository root
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm test infrastructure and familiarize with the existing subscription machinery before making changes.
+
+- [x] T001 Read `core/src/Juice.EventBus/Subscriptions/InMemorySubscriptionsManager.cs` and verify `internal` visibility — determine if `InternalsVisibleTo` for `Juice.Messaging.Local` is needed
+- [x] T002 [P] Read `core/test/Juice.Messaging.Local.Tests/Juice.Messaging.Local.Tests.csproj` to confirm project references and verify `Juice.EventBus` is already referenced
+- [x] T003 [P] Read `core/src/Juice.Messaging.Local/Juice.Messaging.Local.csproj` to confirm project references for `Juice.EventBus` (needed for `ISubscriptionsManager`, `InMemorySubscriptionsManager`)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Implement `LocalConsumerBuilder` and `AddLocalConsumer` — these are required by ALL user stories because they are what populates the keyed `ISubscriptionsManager` that US2 and US3 consume.
+
+**⚠️ CRITICAL**: US2 and US3 cannot be implemented until this phase is complete.
+
+- [x] T004 Create `core/src/Juice.Messaging.Local/Internal/LocalConsumerBuilder.cs` — `internal sealed` class with `IServiceCollection _services`, `List<SubscriptionInfo> _subscriptions`, `Subscribe<TEvent, THandler>(string? key = null)` method that calls `services.TryAddTransient<THandler>()` and accumulates a `SubscriptionInfo.Typed(typeof(TEvent), typeof(THandler), key)`, and `Build()` returning `new InMemorySubscriptionsProvider(_subscriptions)`
+- [x] T005 Add `AddLocalConsumer(this MessagingBuilder builder, Action<LocalConsumerBuilder> configure)` method to `core/src/Juice.Messaging.Local/DependencyInjection/LocalMessagingBuilderExtensions.cs` — creates `LocalConsumerBuilder(builder.Services)`, calls `configure(consumerBuilder)`, registers the resulting `ISubscriptionsProvider` via `builder.Services.AddSingleton<ISubscriptionsProvider>(provider)`, then calls `builder.Services.TryAddKeyedSingleton<ISubscriptionsManager>("local", (sp, _) => new InMemorySubscriptionsManager(sp.GetServices<ISubscriptionsProvider>(), sp.GetRequiredService<ILogger<InMemorySubscriptionsManager>>(), topicSupport: false))`
+
+**Checkpoint**: After T004–T005, calling `AddLocalConsumer(c => c.Subscribe<TEvent, THandler>())` registers a keyed `ISubscriptionsManager` with the subscription recorded.
+
+---
+
+## Phase 3: User Story 1 — Register Local Handler via Subscriptions Manager (Priority: P1) 🎯 MVP
+
+**Goal**: After calling `AddLocalConsumer`, the keyed `ISubscriptionsManager` (key `"local"`) returns the registered handler types when queried by event name.
+
+**Independent Test**: Build a minimal service collection with `AddLocalConsumer(c => c.Subscribe<TestEvent, TestHandler>())`, resolve `ISubscriptionsManager` (key `"local"`), call `GetHandlersForEventAsync("TestEvent")`, assert `TestHandler` is returned.
+
+### Implementation for User Story 1
+
+- [x] T006 [US1] Verify `InMemorySubscriptionsManager` constructor is accessible from `Juice.Messaging.Local` — if it is `internal`, add `[assembly: InternalsVisibleTo("Juice.Messaging.Local")]` to `core/src/Juice.EventBus/Assembly.cs` (or create that file if absent), mirroring how other projects in the solution expose internals
+- [x] T007 [P] [US1] Write unit test `Subscribe_registers_handler_in_subscriptions_manager_Async` in `core/test/Juice.Messaging.Local.Tests/LocalConsumerBuilderTests.cs` — builds `ServiceCollection`, calls `AddLocalConsumer(c => c.Subscribe<OrderCreatedEvent, OrderCreatedHandler>())`, resolves `ISubscriptionsManager` keyed `"local"`, asserts `GetHandlersForEventAsync("OrderCreatedEvent")` returns `typeof(OrderCreatedHandler)`
+- [x] T008 [P] [US1] Write unit test `Subscribe_is_idempotent_for_same_event_handler_pair_Async` in `core/test/Juice.Messaging.Local.Tests/LocalConsumerBuilderTests.cs` — calls `Subscribe<TEvent, THandler>()` twice on the same builder, asserts handler type appears exactly once in `GetHandlersForEventAsync`
+- [x] T009 [P] [US1] Write unit test `Multiple_handlers_for_same_event_are_all_returned_Async` in `core/test/Juice.Messaging.Local.Tests/LocalConsumerBuilderTests.cs` — registers two handlers for the same event, asserts both types are returned
+- [x] T010 [P] [US1] Write unit test `Multiple_AddLocalConsumer_calls_are_additive_Async` in `core/test/Juice.Messaging.Local.Tests/LocalConsumerBuilderTests.cs` — calls `AddLocalConsumer` twice on the same `MessagingBuilder`, asserts handlers from both calls are returned
+- [x] T011 [US1] Write unit test `No_handlers_registered_returns_empty_not_throws_Async` in `core/test/Juice.Messaging.Local.Tests/LocalConsumerBuilderTests.cs` — calls `AddLocalConsumer` with no subscriptions, asserts `GetHandlersForEventAsync("UnknownEvent")` returns empty without throwing
+
+**Checkpoint**: `LocalConsumerBuilderTests` all pass. Developer can register handlers and query the registry independently of dispatch.
+
+---
+
+## Phase 4: User Story 2 — Dispatch via Subscriptions Manager on Local-Channel Route (Priority: P2)
+
+**Goal**: When `AddLocalConsumer` has been called, publishing an event on `"local-channel"` invokes only the handlers registered in the subscriptions manager — not all handlers in DI. When `AddLocalConsumer` was NOT called, the existing DI-scan fallback runs unchanged.
+
+**Independent Test**: Register `TestHandler` via `AddLocalConsumer`, publish a `TestEvent` to the `"local-channel"` channel writer, wait for the channel to drain, assert `TestHandler.HandleAsync` was called. Then assert a second handler in DI (but not in the subscriptions manager) was NOT called.
+
+### Implementation for User Story 2
+
+- [x] T012 [US2] Modify `LocalDispatchHelper.DispatchIntegrationEventAsync` in `core/src/Juice.Messaging.Local/Internal/LocalDispatchHelper.cs` — add `ISubscriptionsManager? subscriptionsManager` as the third parameter (before `IIntegrationEvent evt`); replace the unconditional `serviceProvider.GetServices(handlerType)` DI scan with: if `subscriptionsManager != null` → `await subscriptionsManager.GetHandlersForEventAsync(evt.GetType().Name)` → `handlerTypes`; else → existing DI scan fallback
+- [x] T013 [US2] Modify `LocalChannelBackgroundService` constructor in `core/src/Juice.Messaging.Local/Internal/LocalChannelBackgroundService.cs` — add `ISubscriptionsManager? subscriptionsManager = null` parameter (use `[FromKeyedServices("local")]` attribute on .NET 8+; for net6 resolve via `sp.GetKeyedService<ISubscriptionsManager>("local")` in constructor body from an injected `IServiceProvider`), store in `_subscriptionsManager` field; update the `LocalDispatchHelper.DispatchIntegrationEventAsync(sp, dispatcher, integrationEvent, ...)` call to pass `_subscriptionsManager` as the new third argument
+- [x] T014 [P] [US2] Write integration test `Local_channel_dispatches_to_registered_handler_via_subscriptions_manager_Async` in `core/test/Juice.Messaging.Local.Tests/LocalChannelTests.cs` — sets up host with `AddLocalChannel()` + `AddLocalConsumer(c => c.Subscribe<TestEvent, SpyHandler>())`, writes event to channel, waits for dispatch, asserts `SpyHandler` was invoked
+- [x] T015 [P] [US2] Write integration test `Local_channel_does_not_invoke_unregistered_handler_when_manager_present_Async` in `core/test/Juice.Messaging.Local.Tests/LocalChannelTests.cs` — registers `SpyHandler` in DI but NOT via `AddLocalConsumer`, publishes event, asserts `SpyHandler` was NOT invoked (dispatch result is `NotHandled`)
+- [x] T016 [P] [US2] Write integration test `Local_channel_fallback_to_di_scan_when_no_manager_Async` in `core/test/Juice.Messaging.Local.Tests/LocalChannelTests.cs` — sets up host with `AddLocalChannel()` only (no `AddLocalConsumer`), registers `SpyHandler` directly in DI, publishes event, asserts `SpyHandler` WAS invoked (fallback path)
+- [x] T017 [P] [US2] Write integration test `Local_channel_returns_not_handled_when_no_handlers_in_manager_Async` in `core/test/Juice.Messaging.Local.Tests/LocalChannelTests.cs` — registers no handlers in manager for the published event type, asserts dispatch result is `NotHandled` and no exception is raised
+
+**Checkpoint**: `LocalChannelTests` pass. Publishing on `"local-channel"` uses subscriptions manager when registered; falls back to DI scan otherwise.
+
+---
+
+## Phase 5: User Story 3 — Dispatch via Subscriptions Manager on Local (Outbox-Backed) Route (Priority: P3)
+
+**Goal**: When `AddLocalConsumer` has been called, `LocalTransportPublisher` (invoked by `DeliveryHostedService` for `PublisherKey = "local"`) also uses the subscriptions manager for handler resolution — identical dispatch logic to the local-channel path.
+
+**Independent Test**: Register `TestHandler` via `AddLocalConsumer`, save an outbox record for `PublisherKey = "local"`, let `DeliveryHostedService` process it via `LocalTransportPublisher`, assert `TestHandler.HandleAsync` was called.
+
+### Implementation for User Story 3
+
+- [x] T018 [US3] Modify `LocalTransportPublisher` constructor in `core/src/Juice.Messaging.Local/Internal/LocalTransportPublisher.cs` — add `ISubscriptionsManager? subscriptionsManager = null` parameter (same keyed injection pattern as T013), store in `_subscriptionsManager` field; update the `LocalDispatchHelper.DispatchIntegrationEventAsync(scope.ServiceProvider, _dispatcher, integrationEvent, ...)` call to pass `_subscriptionsManager` as the new third argument
+- [x] T019 [P] [US3] Write integration test `Local_transport_dispatches_to_registered_handler_via_subscriptions_manager_Async` in `core/test/Juice.Messaging.Local.Tests/LocalTransportPublisherTests.cs` — instantiates `LocalTransportPublisher` with a mock/stub `ISubscriptionsManager` that returns `typeof(SpyHandler)` for the test event name, calls `PublishAsync` with a serialized event payload, asserts `SpyHandler` was invoked
+- [x] T020 [P] [US3] Write integration test `Local_transport_fallback_to_di_scan_when_no_manager_Async` in `core/test/Juice.Messaging.Local.Tests/LocalTransportPublisherTests.cs` — instantiates `LocalTransportPublisher` with `subscriptionsManager: null`, registers `SpyHandler` in DI, calls `PublishAsync`, asserts `SpyHandler` WAS invoked (fallback)
+- [x] T021 [P] [US3] Write integration test `Local_transport_idempotency_dedup_respected_Async` in `core/test/Juice.Messaging.Local.Tests/LocalTransportPublisherTests.cs` — calls `PublishAsync` twice with the same `MessageId`/source headers, asserts handler invoked once and second delivery returns `Duplicated`
+
+**Checkpoint**: `LocalTransportPublisherTests` pass. All three delivery routes use subscriptions manager consistently.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, backward-compat validation, and xml doc comments.
+
+- [x] T022 [P] Add XML doc comment to `AddLocalConsumer` in `core/src/Juice.Messaging.Local/DependencyInjection/LocalMessagingBuilderExtensions.cs` — describe purpose, keyed manager key `"local"`, idempotent-call behavior, and backward-compat fallback
+- [x] T023 [P] Add XML doc comment to `LocalConsumerBuilder` class and its `Subscribe` method in `core/src/Juice.Messaging.Local/Internal/LocalConsumerBuilder.cs` — describe DI registration side-effect and idempotency
+- [x] T024 Run the quickstart.md test scenario end-to-end to validate the full developer experience: set up host per `quickstart.md`, publish `OrderCreatedEvent`, assert `OrderCreatedHandler` invoked — capture result in a comment in `core/test/Juice.Messaging.Local.Tests/LocalChannelTests.cs`
+- [x] T025 Verify no existing tests in `core/test/Juice.Messaging.Local.Tests/` regress — run the full test project and confirm all pre-existing tests pass with the modified `LocalDispatchHelper`, `LocalChannelBackgroundService`, and `LocalTransportPublisher`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS all user stories (T004–T005 must be complete)
+- **US1 (Phase 3)**: Depends on Phase 2 — can start after T005
+- **US2 (Phase 4)**: Depends on Phase 2 and US1 (needs `LocalConsumerBuilder` + working registration) — T012 modifies `LocalDispatchHelper` which is the core behavioral change
+- **US3 (Phase 5)**: Depends on T012 (the `LocalDispatchHelper` signature change) — can proceed in parallel with US2 tests (T019–T021) once T012 is done
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after Phase 2 — no dependencies on US2/US3
+- **US2 (P2)**: Depends on US1 (T006 must be resolved first; T012 is the core change)
+- **US3 (P3)**: Depends on T012 (same helper, same pattern) — can be done in parallel with US2 tests
+
+### Within Each Phase
+
+- T006 (internals visibility check) must complete before T007–T011 (tests need to compile)
+- T004 must complete before T005 (builder depends on `LocalConsumerBuilder`)
+- T012 must complete before T013 and T018 (both callers need the new signature)
+- T013 must complete before T014–T017 (tests exercise the modified service)
+- T018 must complete before T019–T021 (tests exercise the modified publisher)
+
+### Parallel Opportunities
+
+- T002 and T003 (Phase 1) run in parallel
+- T007, T008, T009, T010, T011 (US1 tests) run in parallel after T006
+- T014, T015, T016, T017 (US2 tests) run in parallel after T013
+- T019, T020, T021 (US3 tests) run in parallel after T018
+- T022 and T023 (Phase 6 doc tasks) run in parallel
+- US2 tests (T014–T017) and US3 implementation (T018) can overlap after T012
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+# After T006 resolves internals visibility, all US1 tests can run in parallel:
+T007 — Subscribe registers handler
+T008 — Subscribe is idempotent
+T009 — Multiple handlers returned
+T010 — Multiple AddLocalConsumer calls are additive
+T011 — No handlers returns empty
+```
+
+## Parallel Example: User Story 2
+
+```text
+# After T013 (LocalChannelBackgroundService modified), all US2 tests run in parallel:
+T014 — Registered handler is invoked
+T015 — Unregistered handler not invoked
+T016 — Fallback to DI scan works
+T017 — NotHandled when no handlers
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001–T003)
+2. Complete Phase 2: Foundational (T004–T005) — **CRITICAL**
+3. Complete Phase 3: US1 (T006–T011)
+4. **STOP and VALIDATE**: `GetHandlersForEventAsync` returns registered types — registry works
+5. This alone delivers SC-001 (introspection capability)
+
+### Incremental Delivery
+
+1. Setup + Foundational → `LocalConsumerBuilder` and `AddLocalConsumer` working
+2. US1 → Handler registration queryable — demo-able as diagnostics/introspection tool
+3. US2 → Local-channel dispatch uses registry — SC-002 achieved
+4. US3 → Local (outbox) dispatch uses registry — SC-003 achieved, full parity
+5. Polish → docs and regression check
+
+### Parallel Team Strategy
+
+With two developers after Phase 2:
+- Dev A: US1 (T006–T011) → then US2 implementation (T012–T013)
+- Dev B: Read ahead on US3 pattern → implement T018 once T012 is merged
+
+---
+
+## Notes
+
+- `[P]` tasks = different files, no shared-state conflicts, safe to parallelize
+- `[Story]` label maps each task to its user story for traceability
+- Each user story is independently completable and testable
+- No DB migrations needed — all changes are in-memory runtime only
+- `IgnoreOnCIFact` is NOT needed for any of these tests — no external infra required
+- `[InitializeMessageContext]` is required on test classes that exercise the local-channel dispatch path
+- Commit after each checkpoint to keep the branch bisectable


### PR DESCRIPTION
Introduces LocalConsumerBuilder and AddLocalConsumer extension on MessagingBuilder so developers can explicitly register integration event handlers for in-process routes via the subscriptions manager, mirroring the RabbitMQ consumer registration API.

- Add ILocalSubscriptionsProvider marker interface (Juice.EventBus) to isolate local-route providers from broker subscription managers
- Add AddLocalSubscriptionsManager extension that registers a keyed ISubscriptionsManager ("local") populated from ILocalSubscriptionsProvider instances (topicSupport: false, exact-name matching)
- Add LocalConsumerBuilder implementing ILocalSubscriptionsProvider; Subscribe<TEvent,THandler> accumulates SubscriptionInfo + TryAddTransient
- Add AddLocalConsumer(MessagingBuilder, Action<LocalConsumerBuilder>) which registers the builder as ILocalSubscriptionsProvider and ensures the keyed manager is registered
- Extend LocalDispatchHelper.DispatchIntegrationEventAsync with an ISubscriptionsManager? parameter; uses it when non-null, falls back to DI scan when null (backward-compatible)
- LocalChannelBackgroundService and LocalTransportPublisher resolve GetKeyedService<ISubscriptionsManager>("local") from the per-dispatch scope and pass it to the dispatch helper
- Add LocalConsumerBuilderTests (6 unit tests, US1) and integration tests for US2 (local-channel) and US3 (local transport); 40/40 pass on net6/net8/net9