### PR TITLE
feat: per-processor delivery policies with global fallback; bump vers…

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     <PackageIconUrl>https://avatars.githubusercontent.com/u/107674950</PackageIconUrl>
     <RepositoryUrl>https://github.com/creatorflow-io/Juice</RepositoryUrl>
 
-    <VersionPrefix>9.5.2</VersionPrefix>
+    <VersionPrefix>9.5.3</VersionPrefix>
     <VersionSuffix>local.$([System.DateTime]::Now.ToString(`yyyyMMdd`)).1</VersionSuffix>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/core/src/Juice.Messaging.Outbox.Delivery/DeliveryBuilder.cs
+++ b/core/src/Juice.Messaging.Outbox.Delivery/DeliveryBuilder.cs
@@ -37,6 +37,8 @@ namespace Juice.Messaging.Outbox.Delivery
 
             configure?.Invoke(builder);
 
+            builder.RegisterProcessorPolicies<TContext>();
+
             _services.AddHostedService(sp => builder.BuildHostedService<TContext>(sp));
             return this;
         }
@@ -54,6 +56,8 @@ namespace Juice.Messaging.Outbox.Delivery
 
             // ✅ Register default intents automatically if not configured
             builder.WithIntents(intents);
+
+            builder.RegisterProcessorPolicies<TContext>();
 
             _services.AddHostedService(sp => builder.BuildHostedService<TContext>(sp));
             return this;

--- a/core/src/Juice.Messaging.Outbox.Delivery/Internal/DeliveryPolicyConfiguration.cs
+++ b/core/src/Juice.Messaging.Outbox.Delivery/Internal/DeliveryPolicyConfiguration.cs
@@ -1,54 +1,70 @@
-﻿using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Options;
 
 namespace Juice.Messaging.Outbox.Delivery.Internal
 {
     internal sealed class DeliveryPolicyConfiguration : IDeliveryPolicyProvider
     {
         private readonly DeliveryPolicyOptions _options;
-        
-        public DeliveryPolicyConfiguration(IOptions<DeliveryPolicyOptions> options)
+        private readonly IOptionsMonitor<DeliveryPolicyOptions> _optionsMonitor;
+        private readonly ProcessorPolicyRegistry? _processorRegistry;
+
+        public DeliveryPolicyConfiguration(
+            IOptions<DeliveryPolicyOptions> options,
+            IOptionsMonitor<DeliveryPolicyOptions> optionsMonitor,
+            IEnumerable<ProcessorPolicyRegistry> processorRegistries)
         {
             _options = options.Value;
+            _optionsMonitor = optionsMonitor;
+            _processorRegistry = processorRegistries.FirstOrDefault();
             _options.Policies = (_options.Policies ?? [])
                 .ToDictionary(kvp => kvp.Key.Replace("__",":"), kvp => kvp.Value);
         }
-        
+
         public ValueTask<DeliveryPolicy> GetPolicyAsync(DeliveryContext context, CancellationToken cancellationToken)
         {
-            // Try exact match first: "publisher:intent:context"
+            // Steps 1–4: global key-matched entries (highest priority — config-section entries live here)
             var exactKey = $"{context.PublisherKey}:{context.Intent}:{context.Context}";
             if (_options.Policies.TryGetValue(exactKey, out var exactConfig))
             {
                 return ValueTask.FromResult(exactConfig.ToPolicy(_options.DefaultPolicy?.ToPolicy()));
             }
-            
-            // Try publisher + intent: "publisher:intent:*"
+
             var publisherIntentKey = $"{context.PublisherKey}:{context.Intent}:*";
             if (_options.Policies.TryGetValue(publisherIntentKey, out var piConfig))
             {
                 return ValueTask.FromResult(piConfig.ToPolicy(_options.DefaultPolicy?.ToPolicy()));
             }
-            
-            // Try publisher wildcard: "publisher:*:*"
+
             var publisherKey = $"{context.PublisherKey}:*:*";
             if (_options.Policies.TryGetValue(publisherKey, out var pConfig))
             {
                 return ValueTask.FromResult(pConfig.ToPolicy(_options.DefaultPolicy?.ToPolicy()));
             }
-            
-            // Try intent wildcard: "*:intent:*"
+
             var intentKey = $"*:{context.Intent}:*";
             if (_options.Policies.TryGetValue(intentKey, out var iConfig))
             {
                 return ValueTask.FromResult(iConfig.ToPolicy(_options.DefaultPolicy?.ToPolicy()));
             }
-            
-            // Use default policy from configuration or system default
+
+            // Step 5: processor code policies — below key-matched global entries, above global DefaultPolicy
+            var processorKey = $"{context.PublisherKey}:{context.Context}";
+            if (_processorRegistry?.IsConfigured(processorKey) == true)
+            {
+                var processorOpts = _optionsMonitor.Get(processorKey);
+                if (processorOpts.DefaultPolicy != null)
+                {
+                    return ValueTask.FromResult(processorOpts.DefaultPolicy.ToPolicy(_options.DefaultPolicy?.ToPolicy()));
+                }
+            }
+
+            // Step 6: global DefaultPolicy
             if (_options.DefaultPolicy != null)
             {
                 return ValueTask.FromResult(_options.DefaultPolicy.ToPolicy());
             }
-            
+
+            // Step 7: built-in default
             return ValueTask.FromResult(DeliveryPolicy.Default);
         }
     }

--- a/core/src/Juice.Messaging.Outbox.Delivery/Internal/ProcessorPolicyRegistry.cs
+++ b/core/src/Juice.Messaging.Outbox.Delivery/Internal/ProcessorPolicyRegistry.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Juice.Messaging.Outbox.Delivery.Internal
+{
+    internal sealed class ProcessorPolicyRegistry
+    {
+        private readonly HashSet<string> _keys = new();
+
+        public bool Register(string key) => _keys.Add(key);
+        public bool IsConfigured(string key) => _keys.Contains(key);
+
+        internal static ProcessorPolicyRegistry GetOrCreate(IServiceCollection services)
+        {
+            var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(ProcessorPolicyRegistry));
+            if (descriptor?.ImplementationInstance is ProcessorPolicyRegistry existing)
+                return existing;
+            var registry = new ProcessorPolicyRegistry();
+            services.AddSingleton(registry);
+            return registry;
+        }
+    }
+}

--- a/core/src/Juice.Messaging.Outbox.Delivery/Processing/DeliveryProcessorBuilder.cs
+++ b/core/src/Juice.Messaging.Outbox.Delivery/Processing/DeliveryProcessorBuilder.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Juice.Messaging.Outbox.Delivery.Internal;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Juice.Messaging.Outbox.Delivery.Processing
@@ -8,6 +10,8 @@ namespace Juice.Messaging.Outbox.Delivery.Processing
         private readonly IServiceCollection _services;
         private readonly string _publisher;
         private readonly HashSet<string> _intents = [];
+        private readonly List<IConfigurationSection> _sectionConfigures = [];
+        private readonly List<Action<DeliveryPolicyOptions>> _policyConfigures = [];
 
         public DeliveryProcessorBuilder(string publisher, IServiceCollection services)
         {
@@ -41,6 +45,54 @@ namespace Juice.Messaging.Outbox.Delivery.Processing
             _intents.Add(DeliveryIntents.RetryFailed);
             _intents.Add(DeliveryIntents.RecoverTimeout);
             return this;
+        }
+
+        /// <summary>
+        /// Configures delivery policies for this processor from a configuration section.
+        /// Safe to call multiple times — each call's settings are merged.
+        /// These policies sit below global config-section key-matched entries but above the global DefaultPolicy.
+        /// </summary>
+        public DeliveryProcessorBuilder AddDeliveryPolicies(IConfigurationSection policies)
+        {
+            _sectionConfigures.Add(policies);
+            return this;
+        }
+
+        /// <summary>
+        /// Configures delivery policies for this processor via a delegate.
+        /// Safe to call multiple times — each call's settings are merged.
+        /// These policies sit below global config-section key-matched entries but above the global DefaultPolicy.
+        /// </summary>
+        public DeliveryProcessorBuilder AddDeliveryPolicies(Action<DeliveryPolicyOptions> configure)
+        {
+            _policyConfigures.Add(configure);
+            return this;
+        }
+
+        /// <summary>
+        /// Registers accumulated processor-scoped policies as named <see cref="DeliveryPolicyOptions"/>
+        /// under the key <c>"{publisher}:{typeof(TContext).Name}"</c>.
+        /// No-op if no policies were added via <see cref="AddDeliveryPolicies(IConfigurationSection)"/>
+        /// or <see cref="AddDeliveryPolicies(Action{DeliveryPolicyOptions})"/>.
+        /// </summary>
+        internal void RegisterProcessorPolicies<TContext>()
+        {
+            if (_sectionConfigures.Count == 0 && _policyConfigures.Count == 0)
+                return;
+
+            var processorKey = $"{_publisher}:{typeof(TContext).Name}";
+            ProcessorPolicyRegistry.GetOrCreate(_services).Register(processorKey);
+
+            foreach (var section in _sectionConfigures)
+                _services.Configure<DeliveryPolicyOptions>(processorKey, section);
+
+            foreach (var action in _policyConfigures)
+                _services.Configure<DeliveryPolicyOptions>(processorKey, action);
+
+            // Ensure provider + resolver are registered even if AddDeliveryPolicies was never called
+            // on DeliveryBuilder directly.
+            _services.TryAddEnumerable(ServiceDescriptor.Singleton<IDeliveryPolicyProvider, DeliveryPolicyConfiguration>());
+            _services.TryAddSingleton<IDeliveryPolicyResolver, DefaultDeliveryPolicyResolver>();
         }
 
         internal CompositeDeliveryHostedService<TContext> BuildHostedService<TContext>(IServiceProvider sp)

--- a/core/test/Juice.EventBus.Tests/DeliveryPoliciesTest.cs
+++ b/core/test/Juice.EventBus.Tests/DeliveryPoliciesTest.cs
@@ -132,5 +132,141 @@ namespace Juice.EventBus.Tests
             sendPolicy.BatchSize.Should().Be(7);
             retryPolicy.BatchSize.Should().Be(25);
         }
+
+        // US1: processor code policy is used when no global key-matched entry exists
+        [Fact(DisplayName = "Processor code policy is used when no global key match exists")]
+        public async Task Processor_Code_Policy_Used_When_No_Global_Key_MatchAsync()
+        {
+            var services = new ServiceCollection();
+            services.AddMessaging()
+                .AddDelivery(delivery =>
+                {
+                    delivery.AddDeliveryProcessor<ProcessorPolicyTestContext>("rabbitmq", proc =>
+                        proc.AddDeliveryPolicies(opts =>
+                            opts.DefaultPolicy = new PolicyConfiguration { BatchSize = 50 }));
+                });
+
+            var provider = services.BuildServiceProvider();
+            var resolver = provider.GetRequiredService<IDeliveryPolicyResolver>();
+
+            var policy = await resolver.GetPolicyAsync(
+                new DeliveryContext("rabbitmq", "send-pending", nameof(ProcessorPolicyTestContext)),
+                CancellationToken.None);
+
+            policy.BatchSize.Should().Be(50);
+        }
+
+        // US1: global config-section key-matched entry wins over processor code policy
+        [Fact(DisplayName = "Global config-section key match overrides processor code policy")]
+        public async Task Global_Config_Section_Key_Match_Overrides_Processor_Code_PolicyAsync()
+        {
+            var contextName = nameof(ProcessorPolicyTestContext);
+            var inMemoryConfig = new Dictionary<string, string?>
+            {
+                [$"GlobalPolicies:Policies:rabbitmq__send-pending__{contextName}:BatchSize"] = "30"
+            };
+            var cfg = new ConfigurationBuilder().AddInMemoryCollection(inMemoryConfig).Build();
+
+            var services = new ServiceCollection();
+            services.AddMessaging()
+                .AddDelivery(delivery =>
+                {
+                    delivery
+                        .AddDeliveryPolicies(cfg.GetSection("GlobalPolicies"))
+                        .AddDeliveryProcessor<ProcessorPolicyTestContext>("rabbitmq", proc =>
+                            proc.AddDeliveryPolicies(opts =>
+                                opts.DefaultPolicy = new PolicyConfiguration { BatchSize = 50 }));
+                });
+
+            var provider = services.BuildServiceProvider();
+            var resolver = provider.GetRequiredService<IDeliveryPolicyResolver>();
+
+            var policy = await resolver.GetPolicyAsync(
+                new DeliveryContext("rabbitmq", "send-pending", contextName),
+                CancellationToken.None);
+
+            policy.BatchSize.Should().Be(30);
+        }
+
+        // US2: processor without code policy falls back to global delegate policy
+        [Fact(DisplayName = "Processor without code policy falls back to global policy")]
+        public async Task Processor_Without_Code_Policy_Falls_Back_To_GlobalAsync()
+        {
+            var services = new ServiceCollection();
+            services.AddMessaging()
+                .AddDelivery(delivery =>
+                {
+                    delivery
+                        .AddDeliveryPolicies(opts =>
+                            opts.DefaultPolicy = new PolicyConfiguration { BatchSize = 20 })
+                        .AddDeliveryProcessor<ProcessorPolicyTestContext>("rabbitmq");
+                });
+
+            var provider = services.BuildServiceProvider();
+            var resolver = provider.GetRequiredService<IDeliveryPolicyResolver>();
+
+            var policy = await resolver.GetPolicyAsync(
+                new DeliveryContext("rabbitmq", "send-pending", nameof(ProcessorPolicyTestContext)),
+                CancellationToken.None);
+
+            policy.BatchSize.Should().Be(20);
+        }
+
+        // US2: processor and global both absent — built-in defaults apply
+        [Fact(DisplayName = "Processor without any policy uses built-in defaults")]
+        public async Task Processor_Without_Any_Policy_Uses_Built_In_DefaultsAsync()
+        {
+            var services = new ServiceCollection();
+            services.AddMessaging()
+                .AddDelivery(delivery =>
+                {
+                    delivery
+                        .AddDeliveryPolicies(opts => { }) // register resolver, no policy values set
+                        .AddDeliveryProcessor<ProcessorPolicyTestContext>("rabbitmq");
+                });
+
+            var provider = services.BuildServiceProvider();
+            var resolver = provider.GetRequiredService<IDeliveryPolicyResolver>();
+
+            var policy = await resolver.GetPolicyAsync(
+                new DeliveryContext("rabbitmq", "send-pending", nameof(ProcessorPolicyTestContext)),
+                CancellationToken.None);
+
+            policy.BatchSize.Should().Be(DeliveryPolicy.Default.BatchSize);
+            policy.Interval.Should().Be(DeliveryPolicy.Default.Interval);
+        }
+
+        // US3: processor code policy sets only one field; remaining fields come from global default
+        [Fact(DisplayName = "Processor code policy partially overrides global and inherits remaining fields")]
+        public async Task Processor_Code_Policy_Partially_Overrides_Global_Inherits_RestAsync()
+        {
+            var services = new ServiceCollection();
+            services.AddMessaging()
+                .AddDelivery(delivery =>
+                {
+                    delivery
+                        .AddDeliveryPolicies(opts =>
+                            opts.DefaultPolicy = new PolicyConfiguration
+                            {
+                                BatchSize = 10,
+                                Interval = TimeSpan.FromSeconds(5)
+                            })
+                        .AddDeliveryProcessor<ProcessorPolicyTestContext>("rabbitmq", proc =>
+                            proc.AddDeliveryPolicies(opts =>
+                                opts.DefaultPolicy = new PolicyConfiguration { BatchSize = 50 }));
+                });
+
+            var provider = services.BuildServiceProvider();
+            var resolver = provider.GetRequiredService<IDeliveryPolicyResolver>();
+
+            var policy = await resolver.GetPolicyAsync(
+                new DeliveryContext("rabbitmq", "send-pending", nameof(ProcessorPolicyTestContext)),
+                CancellationToken.None);
+
+            policy.BatchSize.Should().Be(50);
+            policy.Interval.Should().Be(TimeSpan.FromSeconds(5));
+        }
+
+        private sealed class ProcessorPolicyTestContext { }
     }
 }

--- a/specs/009-processor-delivery-policy/checklists/requirements.md
+++ b/specs/009-processor-delivery-policy/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Per-Processor Delivery Policy
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. Ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/009-processor-delivery-policy/contracts/delivery-processor-builder-api.md
+++ b/specs/009-processor-delivery-policy/contracts/delivery-processor-builder-api.md
@@ -1,0 +1,107 @@
+# Contract: DeliveryProcessorBuilder API
+
+**Branch**: `009-processor-delivery-policy` | **Date**: 2026-03-27
+
+## New Public Methods on `DeliveryProcessorBuilder`
+
+`DeliveryProcessorBuilder` is the fluent builder received in the `configure` callback of `AddDeliveryProcessor<TContext>()`.
+
+---
+
+### `AddDeliveryPolicies(IConfigurationSection)`
+
+```
+DeliveryProcessorBuilder AddDeliveryPolicies(IConfigurationSection policies)
+```
+
+Configures delivery policies for this processor from a configuration section. The section is bound to `DeliveryPolicyOptions` (same shape as the global `AddDeliveryPolicies` on `DeliveryBuilder`).
+
+**Parameters**:
+- `policies` — configuration section whose keys map to `DeliveryPolicyOptions` fields
+
+**Returns**: `this` (fluent)
+
+**Behavior**: Safe to call multiple times — each call's settings are merged (later calls win for overlapping fields).
+
+**appsettings example** — configure just the default policy for this processor:
+```json
+{
+  "MyProcessorPolicy": {
+    "DefaultPolicy": {
+      "BatchSize": 50,
+      "Interval": "00:00:03"
+    }
+  }
+}
+```
+```csharp
+builder.AddDeliveryProcessor<OrderDbContext>("rabbitmq", proc =>
+    proc.AddDeliveryPolicies(config.GetSection("MyProcessorPolicy")));
+```
+
+---
+
+### `AddDeliveryPolicies(Action<DeliveryPolicyOptions>)`
+
+```
+DeliveryProcessorBuilder AddDeliveryPolicies(Action<DeliveryPolicyOptions> configure)
+```
+
+Configures delivery policies for this processor via a delegate.
+
+**Parameters**:
+- `configure` — delegate that receives the `DeliveryPolicyOptions` instance for this processor
+
+**Returns**: `this` (fluent)
+
+**Behavior**: Safe to call multiple times — each delegate is applied in order.
+
+**Examples**:
+
+```csharp
+// Configure only the default policy (common case)
+builder.AddDeliveryProcessor<OrderDbContext>("rabbitmq", proc =>
+    proc.AddDeliveryPolicies(opts => {
+        opts.DefaultPolicy = new PolicyConfiguration {
+            BatchSize = 50,
+            Interval = TimeSpan.FromSeconds(3)
+        };
+    }));
+```
+
+```csharp
+// Override only one field — all others inherit from global/built-in defaults
+builder.AddDeliveryProcessor<AuditDbContext>("local", proc =>
+    proc.AddDeliveryPolicies(opts =>
+        opts.DefaultPolicy = new PolicyConfiguration { BatchSize = 5 }));
+```
+
+---
+
+## Existing API — Unchanged
+
+The following existing methods on `DeliveryBuilder` and `DeliveryProcessorBuilder` are **not changed**:
+
+| Method | Location | Status |
+|--------|----------|--------|
+| `AddDeliveryProcessor<T>(publisher, Action<DeliveryProcessorBuilder>?)` | `DeliveryBuilder` | Unchanged signature |
+| `AddDeliveryProcessor<T>(publisher, params string[])` | `DeliveryBuilder` | Unchanged signature |
+| `AddDeliveryPolicies(IConfigurationSection)` | `DeliveryBuilder` | Unchanged |
+| `AddDeliveryPolicies(Action<DeliveryPolicyOptions>)` | `DeliveryBuilder` | Unchanged |
+| `WithIntents(params string[])` | `DeliveryProcessorBuilder` | Unchanged |
+| `WithDefaultIntents()` | `DeliveryProcessorBuilder` | Unchanged |
+| `ClearIntents()` | `DeliveryProcessorBuilder` | Unchanged |
+
+---
+
+## Policy Resolution Contract
+
+When the delivery worker for processor `(publisher="rabbitmq", TContext=OrderDbContext)` resolves its policy:
+
+1. **Processor-scoped lookup** (new): checks named `DeliveryPolicyOptions` under key `"rabbitmq:OrderDbContext"` — both its `Policies` dictionary and its `DefaultPolicy`.
+2. **Global lookup** (existing): wildcard matching in the unnamed `DeliveryPolicyOptions` followed by global `DefaultPolicy`.
+3. **Built-in default** (existing): `DeliveryPolicy.Default` hardcoded values.
+
+At step 1, if a processor `DefaultPolicy` is found, it is merged on top of the result from step 2 using field-level null-coalescing: only fields explicitly set in the processor policy override the global value; null fields inherit from the globally resolved policy.
+
+**Guarantee**: Processors with no `AddDeliveryPolicies` call behave identically to before this feature (zero behavioral change).

--- a/specs/009-processor-delivery-policy/data-model.md
+++ b/specs/009-processor-delivery-policy/data-model.md
@@ -1,0 +1,111 @@
+# Data Model: Per-Processor Delivery Policy
+
+**Branch**: `009-processor-delivery-policy` | **Date**: 2026-03-27
+
+> No database changes. This document describes the conceptual in-memory model and how existing types relate to the new feature.
+
+---
+
+## Conceptual Entities
+
+### ProcessorKey
+
+A unique string identifier for one delivery processor instance.
+
+**Format**: `"{publisher}:{contextTypeName}"`
+**Example**: `"rabbitmq:OrderDbContext"`, `"local:AuditDbContext"`
+
+Derived at startup from the `publisher` argument and `typeof(TContext).Name` in `AddDeliveryProcessor<TContext>()`. Matches the `PublisherKey` + `Context` fields of `DeliveryContext`.
+
+---
+
+### ProcessorPolicyRegistry (new internal)
+
+Tracks which processor keys have at least one explicitly configured policy.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `_keys` | `HashSet<string>` | Set of processor keys with explicit policies |
+
+**Operations**:
+- `Register(key)` — called at DI configuration time when `AddDeliveryPolicies` is used on a `DeliveryProcessorBuilder`
+- `IsConfigured(key)` — called at policy resolution time
+
+**Lifetime**: Singleton instance stored in `IServiceCollection`. Populated during `ConfigureServices`; read-only at runtime.
+
+---
+
+### DeliveryPolicyOptions (existing — named instances added)
+
+Already exists as a global (unnamed) options registration. This feature adds **named instances** under `ProcessorKey`.
+
+| Field | Type | Processor-level usage |
+|-------|------|-----------------------|
+| `DefaultPolicy` | `PolicyConfiguration?` | Primary use: the per-processor default policy |
+| `Policies` | `Dictionary<string, PolicyConfiguration>` | Optional: per-intent overrides within the processor scope |
+
+**Named instance key**: `ProcessorKey` (e.g. `"rabbitmq:OrderDbContext"`)
+
+---
+
+### PolicyConfiguration (existing — unchanged)
+
+Nullable fields for each delivery tuning parameter. At resolution time, null fields inherit from the next policy in the fallback chain.
+
+| Field | Type | Description |
+|-------|------|-----------------------|
+| `BatchSize` | `int?` | Records per processing cycle |
+| `Interval` | `TimeSpan?` | Delay between cycles |
+| `Timeout` | `TimeSpan?` | In-progress timeout before recovery |
+| `InitialRetryDelay` | `TimeSpan?` | Delay before first retry |
+| `RetryDelayMultiplier` | `double?` | Exponential backoff factor |
+| `MaxRetryAttempts` | `int?` | Cap on retry count |
+
+---
+
+### DeliveryPolicy (existing — unchanged)
+
+The fully resolved, non-nullable policy used by `DeliveryWorker`. Result of merging `PolicyConfiguration` layers.
+
+---
+
+## Resolution Chain
+
+```
+DeliveryContext(PublisherKey, Intent, Context)
+        │
+        ▼
+Step 1: Global Policies["pub:intent:ctx"] match? ──► yes → return (config-section wins)
+        │ no
+        ▼
+Step 2: Global Policies["pub:intent:*"] match?   ──► yes → return
+        │ no
+        ▼
+Step 3: Global Policies["pub:*:*"] match?        ──► yes → return
+        │ no
+        ▼
+Step 4: Global Policies["*:intent:*"] match?     ──► yes → return
+        │ no
+        ▼
+Step 5: ProcessorPolicyRegistry.IsConfigured("{pub}:{ctx}")?
+        │ yes: get named DeliveryPolicyOptions for processor key
+        │      if .DefaultPolicy != null
+        │        → merge on top of global DefaultPolicy
+        │        → return PolicyConfiguration.ToPolicy(global.DefaultPolicy?.ToPolicy())
+        │ no / .DefaultPolicy null
+        ▼
+Step 6: Global DefaultPolicy != null?            ──► yes → return DefaultPolicy.ToPolicy()
+        │ no
+        ▼
+Step 7: DeliveryPolicy.Default (built-in hardcoded values)
+```
+
+**Priority tiers**:
+| Tier | Source | Overrides |
+|------|--------|-----------|
+| Highest | Global `Policies` key-matched entries (steps 1–4) | Everything |
+| Middle | Processor code `DefaultPolicy` (step 5) | Global `DefaultPolicy` + built-in |
+| Lower | Global `DefaultPolicy` (step 6) | Built-in only |
+| Lowest | `DeliveryPolicy.Default` (step 7) | — |
+
+**Key invariant**: Steps 1–4 use the global `Policies` dictionary where config-section bindings land. A per-processor appsettings entry (e.g. `"rabbitmq:send-pending:OrderDbContext"`) goes into this dictionary and thus outranks processor code policies at step 5.

--- a/specs/009-processor-delivery-policy/plan.md
+++ b/specs/009-processor-delivery-policy/plan.md
@@ -1,0 +1,73 @@
+# Implementation Plan: Per-Processor Delivery Policy
+
+**Branch**: `009-processor-delivery-policy` | **Date**: 2026-03-27 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/009-processor-delivery-policy/spec.md`
+
+## Summary
+
+Allow `DeliveryProcessorBuilder` to accept inline `AddDeliveryPolicies` calls that scope delivery policy configuration to a specific processor (publisher + context type). At resolution time the processor-scoped policy is applied first, merging on top of the globally resolved policy, so unset fields fall through to global/wildcard matches and finally to built-in defaults.
+
+All changes are confined to `Juice.Messaging.Outbox.Delivery` — no new projects, no DB changes, no migrations.
+
+## Technical Context
+
+**Language/Version**: C# on .NET 8 / .NET 9 (library targets `netstandard2.1`; runnable hosts target `net8.0;net9.0`)
+**Primary Dependencies**: `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Options` (named options), `Microsoft.Extensions.Hosting`
+**Storage**: N/A — no DB changes
+**Testing**: xUnit + FluentAssertions; existing `DeliveryPoliciesTest.cs` in `core/test/Juice.EventBus.Tests/`
+**Target Platform**: .NET runtime (library — consumed by any host)
+**Project Type**: Library (NuGet package)
+**Performance Goals**: Policy resolution is a one-time startup cost per worker; no throughput impact
+**Constraints**: Zero breaking changes to existing public API; no new public types required
+**Scale/Scope**: Single project change; ~5 files touched
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Lightweight & Dual-Architecture | ✅ PASS | No new abstractions; processor-scoped options are an opt-in layered on top of global config. Zero overhead when not used. |
+| II. Library-First Composability | ✅ PASS | All changes inside `core/src/Juice.Messaging.Outbox.Delivery/`. No circular dependencies introduced. No new library needed. |
+| III. DDD + CQRS | ✅ PASS | No domain model changes. Delivery policy is infrastructure-layer configuration. |
+| IV. Reliable Messaging via Outbox | ✅ PASS | Policy config key pattern `"PublisherKey:IntentName:ContextTypeName"` is preserved. Processor-scoped layer sits above the existing resolution chain; outbox delivery mechanics unchanged. |
+| V. Multi-Tenancy First | ✅ PASS | No tenant-specific changes needed; delivery processors are per-process (not per-tenant). |
+
+**Post-design re-check**: All five principles remain satisfied. No deviations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-processor-delivery-policy/
+├── plan.md              # This file
+├── research.md          # Phase 0 — design decisions
+├── data-model.md        # Phase 1 — conceptual model
+├── quickstart.md        # Phase 1 — usage examples
+├── contracts/
+│   └── delivery-processor-builder-api.md
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code
+
+```text
+core/src/Juice.Messaging.Outbox.Delivery/
+├── DeliveryBuilder.cs                         [MODIFY] call RegisterProcessorPolicies<TContext>()
+├── Processing/
+│   └── DeliveryProcessorBuilder.cs            [MODIFY] add AddDeliveryPolicies + RegisterProcessorPolicies
+├── Internal/
+│   ├── DeliveryPolicyConfiguration.cs         [MODIFY] check processor-scoped named options first
+│   ├── ProcessorPolicyRegistry.cs             [NEW]    tracks which processor keys have explicit policies
+│   └── DeliveryPolicyOptions.cs               [UNMODIFIED]
+
+core/test/Juice.EventBus.Tests/
+└── DeliveryPoliciesTest.cs                    [MODIFY] add per-processor policy tests
+```
+
+**Structure Decision**: Single existing project. All modifications are additive (new methods + one new internal class). Existing public API is unchanged.
+
+## Complexity Tracking
+
+No constitution violations — table omitted.

--- a/specs/009-processor-delivery-policy/quickstart.md
+++ b/specs/009-processor-delivery-policy/quickstart.md
@@ -1,0 +1,119 @@
+# Quickstart: Per-Processor Delivery Policy
+
+**Branch**: `009-processor-delivery-policy` | **Date**: 2026-03-27
+
+---
+
+## Scenario A — Per-processor policy via code
+
+Give a high-throughput RabbitMQ processor a larger batch and faster poll interval, while a background audit processor runs slower.
+
+```csharp
+services.AddMessaging()
+    .AddDelivery(delivery =>
+    {
+        // High-throughput order processor
+        delivery.AddDeliveryProcessor<OrderDbContext>("rabbitmq", proc =>
+            proc.AddDeliveryPolicies(opts =>
+                opts.DefaultPolicy = new PolicyConfiguration
+                {
+                    BatchSize = 100,
+                    Interval = TimeSpan.FromSeconds(1)
+                }));
+
+        // Low-priority audit processor — inherits global defaults for everything else
+        delivery.AddDeliveryProcessor<AuditDbContext>("rabbitmq", proc =>
+            proc.AddDeliveryPolicies(opts =>
+                opts.DefaultPolicy = new PolicyConfiguration
+                {
+                    BatchSize = 5,
+                    Interval = TimeSpan.FromSeconds(30)
+                }));
+    });
+```
+
+---
+
+## Scenario B — Per-processor policy via appsettings
+
+`appsettings.json`:
+```json
+{
+  "Delivery": {
+    "Order": {
+      "DefaultPolicy": {
+        "BatchSize": 100,
+        "Interval": "00:00:01"
+      }
+    },
+    "Audit": {
+      "DefaultPolicy": {
+        "BatchSize": 5,
+        "Interval": "00:00:30"
+      }
+    }
+  }
+}
+```
+
+```csharp
+services.AddMessaging()
+    .AddDelivery(delivery =>
+    {
+        delivery.AddDeliveryProcessor<OrderDbContext>("rabbitmq", proc =>
+            proc.AddDeliveryPolicies(config.GetSection("Delivery:Order")));
+
+        delivery.AddDeliveryProcessor<AuditDbContext>("rabbitmq", proc =>
+            proc.AddDeliveryPolicies(config.GetSection("Delivery:Audit")));
+    });
+```
+
+---
+
+## Scenario C — Global fallback (no processor policy)
+
+Processors without explicit policies use global delivery policies unchanged.
+
+```csharp
+services.AddMessaging()
+    .AddDelivery(delivery =>
+    {
+        // Global policy applies to all processors without their own policy
+        delivery.AddDeliveryPolicies(opts =>
+            opts.DefaultPolicy = new PolicyConfiguration { BatchSize = 20 });
+
+        // This processor has no explicit policy — inherits BatchSize = 20 from global
+        delivery.AddDeliveryProcessor<ReportDbContext>("rabbitmq");
+    });
+```
+
+---
+
+## Scenario D — Partial override
+
+Override only retry settings for one processor; all other parameters come from the global policy.
+
+```csharp
+services.AddMessaging()
+    .AddDelivery(delivery =>
+    {
+        // Global: BatchSize = 20, Interval = 5s, MaxRetryAttempts = 3
+        delivery.AddDeliveryPolicies(opts =>
+            opts.DefaultPolicy = new PolicyConfiguration
+            {
+                BatchSize = 20,
+                Interval = TimeSpan.FromSeconds(5),
+                MaxRetryAttempts = 3
+            });
+
+        // This processor overrides only MaxRetryAttempts; BatchSize and Interval come from global
+        delivery.AddDeliveryProcessor<CriticalDbContext>("rabbitmq", proc =>
+            proc.AddDeliveryPolicies(opts =>
+                opts.DefaultPolicy = new PolicyConfiguration
+                {
+                    MaxRetryAttempts = 10
+                }));
+    });
+```
+
+Result for `CriticalDbContext`: `BatchSize = 20`, `Interval = 5s`, `MaxRetryAttempts = 10`.

--- a/specs/009-processor-delivery-policy/research.md
+++ b/specs/009-processor-delivery-policy/research.md
@@ -1,0 +1,88 @@
+# Research: Per-Processor Delivery Policy
+
+**Branch**: `009-processor-delivery-policy` | **Date**: 2026-03-27
+
+All unknowns resolved from in-repo code — no external research required.
+
+---
+
+## Decision 1: API surface on `DeliveryProcessorBuilder`
+
+**Decision**: Add two new methods mirroring the existing `DeliveryBuilder.AddDeliveryPolicies` overloads:
+- `AddDeliveryPolicies(IConfigurationSection)`
+- `AddDeliveryPolicies(Action<DeliveryPolicyOptions>)`
+
+**Rationale**: Consistency with the existing global API means developers face no new learning curve. The `IConfigurationSection` overload supports appsettings-driven config; the delegate overload supports code-first config. Both are stored in the builder as a list and applied in `RegisterProcessorPolicies<TContext>()` when `TContext` is finally known.
+
+**Alternatives considered**:
+- `AddDeliveryPolicies(Action<PolicyConfiguration>)` (configure only the `DefaultPolicy` field) — rejected because it would be inconsistent with the existing API and would prevent users from also defining per-intent policies within the processor scope.
+- Making `DeliveryProcessorBuilder<TContext>` generic — rejected because it is a breaking API change and gains nothing over the deferred-registration approach.
+
+---
+
+## Decision 2: Storage mechanism for processor-scoped policies
+
+**Decision**: Use ASP.NET Core **named options** — `services.Configure<DeliveryPolicyOptions>(processorKey, ...)` — with processor key `"{publisher}:{typeof(TContext).Name}"`.
+
+**Rationale**: Named options are the idiomatic .NET mechanism for scoped configuration. `IOptionsMonitor<DeliveryPolicyOptions>.Get(key)` retrieves them at resolution time without any additional infrastructure. The processor key matches the two fields already present in `DeliveryContext` (`PublisherKey` + `Context`).
+
+**Alternatives considered**:
+- A custom dictionary of `DeliveryPolicyOptions` keyed by processor key stored as a singleton — rejected as reinventing named options.
+- Keyed DI (`AddKeyedSingleton<DeliveryPolicyOptions>(processorKey)`) — rejected because it cannot be configured incrementally via `Configure<T>` (no `TryConfigureKeyedSingleton`).
+
+---
+
+## Decision 3: Tracking which processor keys have explicit policies
+
+**Decision**: Introduce an internal `ProcessorPolicyRegistry` class — a `HashSet<string>` wrapper registered as a singleton instance in `IServiceCollection` (same pattern as `DeliveryProcessorRegistry`).
+
+**Rationale**: `IOptionsMonitor<T>.Get(name)` always returns a value (never null) — an unconfigured named options entry returns a default-constructed `DeliveryPolicyOptions` with all-null fields. Without a separate registry, there is no way to distinguish "explicitly configured" from "never touched". The registry is populated at DI-configuration time (startup) and is fully populated before any worker resolves its policy.
+
+**Alternatives considered**:
+- Checking if all fields of the returned `DeliveryPolicyOptions` are null/empty — fragile; silently ignores explicit zero/empty values.
+- A `bool` property on the options — not possible without modifying `DeliveryPolicyOptions` and coupling it to the processor concept.
+
+---
+
+## Decision 4: Integration point for processor-scoped resolution
+
+**Decision**: Enhance `DeliveryPolicyConfiguration` (the existing `IDeliveryPolicyProvider`) to insert the processor code policy check **after** the existing four key-match lookups and **before** the global `DefaultPolicy` fallback.
+
+Updated `GetPolicyAsync` resolution chain (7 steps):
+1. Global `Policies` exact key `"publisher:intent:context"` → return (includes config-section entries)
+2. Global `Policies` wildcard `"publisher:intent:*"` → return
+3. Global `Policies` wildcard `"publisher:*:*"` → return
+4. Global `Policies` wildcard `"*:intent:*"` → return
+5. **[NEW]** Processor code policy: if `ProcessorPolicyRegistry.IsConfigured("{PublisherKey}:{Context}")` → get named `DeliveryPolicyOptions` for processor key → if `DefaultPolicy != null` → merge on top of global `DefaultPolicy` via `PolicyConfiguration.ToPolicy(globalDefaultPolicy)` → return
+6. Global `DefaultPolicy` → return
+7. `DeliveryPolicy.Default` (built-in) → return
+
+**Key invariant from `/speckit.clarify`**: Global config-section entries in the `Policies` dictionary (steps 1–4) have **higher** priority than processor code policies (step 5). Only the global `DefaultPolicy` (step 6) is lower. This allows operators to override processor code defaults via appsettings without code changes.
+
+**Rationale**: Single provider handles all levels — no IEnumerable ordering concerns. Processor code policy merges on top of global `DefaultPolicy` (not the key-matched result), so partial overrides inherit correctly from the global default while key-matched entries still win outright.
+
+**Optional injection via `IEnumerable<ProcessorPolicyRegistry>`**: `ProcessorPolicyRegistry` is registered only when at least one processor has explicit policies. `IEnumerable<T>` injection returns an empty collection when no instances are registered, making the constructor safe without conditional registration.
+
+**Alternatives considered**:
+- Registering a second `IDeliveryPolicyProvider` that runs before `DeliveryPolicyConfiguration` — rejected because `TryAddEnumerable` does not guarantee insertion position relative to existing registrations; ordering would be brittle.
+- Checking processor at the very start (before key-match lookups) — rejected after `/speckit.clarify` confirmed that global config-section key entries MUST outrank processor code policies.
+
+---
+
+## Decision 5: `DeliveryProcessorBuilder` — where `RegisterProcessorPolicies<TContext>` is called
+
+**Decision**: Called from `DeliveryBuilder.AddDeliveryProcessor<TContext>()` immediately after `configure?.Invoke(builder)`, before `_services.AddHostedService(...)`.
+
+**Rationale**: At this point `TContext` is known (can compute processor key), the configure delegate has run (policies have been accumulated in the builder), and the service collection is still open. This is the natural place to flush accumulated configuration into the service collection.
+
+---
+
+## Summary of New/Changed Files
+
+| File | Change |
+|------|--------|
+| `Processing/DeliveryProcessorBuilder.cs` | Add `AddDeliveryPolicies` (×2) + `RegisterProcessorPolicies<TContext>()` |
+| `DeliveryBuilder.cs` | Call `procBuilder.RegisterProcessorPolicies<TContext>()` in both `AddDeliveryProcessor` overloads |
+| `Internal/DeliveryPolicyConfiguration.cs` | Inject `ProcessorPolicyRegistry?` + `IOptionsMonitor<DeliveryPolicyOptions>?`; add processor-scope check at top of `GetPolicyAsync` |
+| `Internal/ProcessorPolicyRegistry.cs` | New: `HashSet<string>` wrapper, singleton-instance pattern |
+| `core/test/Juice.EventBus.Tests/DeliveryPoliciesTest.cs` | Add 3 tests: processor policy, fallback, partial override |

--- a/specs/009-processor-delivery-policy/spec.md
+++ b/specs/009-processor-delivery-policy/spec.md
@@ -1,0 +1,113 @@
+# Feature Specification: Per-Processor Delivery Policy
+
+**Feature Branch**: `009-processor-delivery-policy`
+**Created**: 2026-03-27
+**Status**: Draft
+**Input**: User description: "Configure delivery policies by processor, fallback to global policies"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Per-Processor Policy Configuration (Priority: P1)
+
+A developer configuring a microservice wants to tune delivery behaviour differently for each processor — for example, giving a high-throughput RabbitMQ processor a larger batch size and shorter interval, while keeping a lower-volume processor at defaults. They want to set these policies inline when registering the processor, without having to manually craft key patterns in a global policy dictionary.
+
+**Why this priority**: This is the core value of the feature. Without it, per-processor tuning requires knowing the internal key format of the global policy dictionary, which is error-prone and not self-documenting.
+
+**Independent Test**: Can be fully tested by registering a processor with explicit policies and verifying that those policies (batch size, interval, retry settings) are used during delivery for that processor — independently of any global configuration.
+
+**Acceptance Scenarios**:
+
+1. **Given** a processor is registered with an explicit policy (e.g. `BatchSize = 50`), **When** the delivery loop runs for that processor, **Then** deliveries are processed in batches of 50.
+2. **Given** two processors are registered — one with a custom interval and one without, **When** both delivery loops run, **Then** each uses its own configured interval.
+3. **Given** a processor is registered with a partial policy (only `BatchSize` set), **When** the delivery loop runs, **Then** `BatchSize` uses the processor-specific value and all other parameters fall back to the global or built-in defaults.
+4. **Given** a processor code policy sets `BatchSize = 50` and the global config section has a matching key entry setting `BatchSize = 30`, **When** the delivery loop runs, **Then** `BatchSize = 30` (config section key entry wins over processor code policy).
+
+---
+
+### User Story 2 - Global Fallback When No Processor Policy Exists (Priority: P2)
+
+A developer registers a processor without any policy, but has global delivery policies configured. They expect the global policies to apply automatically for that processor.
+
+**Why this priority**: Fallback behaviour is essential for backward compatibility and for applications that use a single global tuning configuration across all processors.
+
+**Independent Test**: Can be fully tested by registering a processor with no policy, configuring global policies, and verifying that the processor uses the global values.
+
+**Acceptance Scenarios**:
+
+1. **Given** a processor is registered with no policy and global policies set `BatchSize = 20`, **When** the delivery loop runs, **Then** the processor uses `BatchSize = 20`.
+2. **Given** no processor policy and no global policy, **When** the delivery loop runs, **Then** built-in defaults apply.
+3. **Given** global policies define only `Timeout`, **When** the delivery loop runs without a processor-specific policy, **Then** `Timeout` comes from global config and all other parameters use built-in defaults.
+
+---
+
+### User Story 3 - Processor Policy Overrides Global Partially (Priority: P3)
+
+A developer has global policies that set most parameters, but wants one processor to override just one setting (e.g. a faster retry delay) while inheriting the rest from global configuration.
+
+**Why this priority**: Partial override eliminates duplication — developers should not have to repeat all global settings just to change one value on a specific processor.
+
+**Independent Test**: Can be fully tested by setting multiple parameters globally, overriding just one at the processor level, and verifying that the processor uses its value for the overridden field and global values for all others.
+
+**Acceptance Scenarios**:
+
+1. **Given** global policy sets `BatchSize = 10` and `Interval = 5s`, and a processor-level policy sets only `BatchSize = 50`, **When** the delivery loop runs for that processor, **Then** `BatchSize = 50` and `Interval = 5s`.
+2. **Given** a processor-level policy sets a field to an explicit value that matches the global value, **When** the delivery loop runs, **Then** behaviour is identical to not specifying that field at the processor level.
+
+---
+
+### Edge Cases
+
+- What happens when both processor-level and global policies are absent? → Built-in defaults must apply without error.
+- What happens when a processor is registered multiple times with different policies (idempotent registration)? → The first registration wins; subsequent calls for the same processor identity are ignored.
+- What happens when `AddDeliveryPolicies` is called on `DeliveryProcessorBuilder` multiple times for the same processor? → Policies are merged (later calls can override individual fields).
+- What happens when the global policy itself is partial (missing some fields)? → Missing fields fall through to built-in defaults.
+- What happens when policy configuration references an unknown processor key? → The configuration is silently ignored (no error); it simply never matches.
+- What happens when both a global config-section entry AND a processor code policy match the same processor? → The config-section entry wins (higher priority per FR-002).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The framework MUST allow delivery policies (batch size, interval, timeout, retry settings) to be configured at the processor registration level, scoped to a specific processor identity (context type + publisher name).
+- **FR-002**: When resolving the delivery policy for a running processor, the framework MUST apply the following priority order:
+  1. Per-key entries in the global config-section `Policies` dictionary (`DeliveryBuilder.AddDeliveryPolicies(IConfigurationSection)`) whose key matches the processor (`"publisher:intent:context"` exact or wildcard). These override processor-scoped code policies.
+  2. Processor-scoped code policies (configured via `DeliveryProcessorBuilder.AddDeliveryPolicies`).
+  3. Global programmatic policies (`DeliveryBuilder.AddDeliveryPolicies(Action<>)`) and the global config-section `DefaultPolicy`.
+  4. Built-in defaults (`DeliveryPolicy.Default`).
+  - **Note**: The global config-section `DefaultPolicy` (top-level, not a per-key entry) does **not** override processor code policies — it remains at priority 3 as a general catch-all.
+- **FR-003**: When no processor-scoped policy exists and no config-section key matches the processor, the framework MUST apply global programmatic policies (if present), then built-in defaults.
+- **FR-004**: Processor-scoped policies MUST support partial configuration — unset fields inherit from the global policy, and any remaining unset fields inherit from built-in defaults.
+- **FR-005**: The policy configuration API MUST be expressible inline within the processor registration call, without requiring a separate global configuration step.
+- **FR-006**: The policy configuration API MUST accept both a configuration section (for appsettings-driven config) and a programmatic delegate, consistent with the existing global `AddDeliveryPolicies` overloads.
+- **FR-007**: Adding processor-scoped policies MUST be safe to call multiple times for the same processor — subsequent calls merge policies rather than producing duplicate registrations or errors.
+- **FR-008**: Adding processor-scoped policies MUST NOT interfere with global policies configured on other processors or at the `DeliveryBuilder` level.
+
+### Key Entities
+
+- **ProcessorIdentity**: The combination of publisher name and context type that uniquely identifies a delivery processor. Used as the lookup key for processor-scoped policies.
+- **PolicyConfiguration**: A set of optional delivery parameters (batch size, interval, timeout, retry delay, retry multiplier, max retries). Absent fields defer to the next policy in the fallback chain.
+- **DeliveryPolicy**: The fully resolved, non-optional set of delivery parameters used by a running processor. Result of merging processor-scoped, global, and built-in defaults.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A developer can configure processor-specific delivery policies with no more lines of code than configuring global policies — the API is at least as ergonomic.
+- **SC-002**: All existing applications that only use global policies continue to work unchanged — zero breaking changes to the existing `AddDeliveryPolicies` API.
+- **SC-003**: When a processor-scoped policy is present, it takes effect on the very first delivery cycle — there is no delay or warm-up period before the policy activates.
+- **SC-004**: Every field of `PolicyConfiguration` can be individually overridden at the processor level; no field is excluded from processor-scoped control.
+- **SC-005**: 100% of existing unit and integration tests pass without modification after the change is applied.
+
+## Assumptions
+
+- The processor identity key is the combination of publisher name and the short context type name (matching the existing `DeliveryContext.PublisherKey` and `DeliveryContext.Context` fields).
+- Processor-scoped policies are registered at startup (DI configuration time), not dynamically at runtime.
+- The policy fallback chain is: **global config-section `Policies` key match** → processor-scoped code policy → global programmatic policy (`Action<>`) + global config-section `DefaultPolicy` → `DeliveryPolicy.Default` (hardcoded built-in values). Only per-key `Policies` entries in the config section outrank processor code policies; the global config-section `DefaultPolicy` does not. This enables operators to override specific processors via appsettings without affecting the general default.
+- "Merge" for partial policies means field-by-field null-coalescing — the same logic already implemented in `PolicyConfiguration.ToPolicy(defaultPolicy)`.
+
+## Clarifications
+
+### Session 2026-03-27
+
+- Q: When does `AddDeliveryPolicies(IConfigurationSection)` on `DeliveryBuilder` override processor-scoped code policies — always, selectively by key, or only at the default level? → A: Selectively — config section entries matching the processor key (`"publisher:intent:context"` or wildcards) override the processor code policy for that specific combination; unmatched processors keep their code policy.
+- Q: Does the global config-section `DefaultPolicy` also override processor code policies, or only per-key `Policies` entries? → A: Only per-key `Policies` entries override processor code; global `DefaultPolicy` stays below processor code in the priority chain.

--- a/specs/009-processor-delivery-policy/tasks.md
+++ b/specs/009-processor-delivery-policy/tasks.md
@@ -1,0 +1,166 @@
+# Tasks: Per-Processor Delivery Policy
+
+**Input**: Design documents from `/specs/009-processor-delivery-policy/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅
+
+**Tests**: Included — the existing codebase has `DeliveryPoliciesTest.cs` and the research.md explicitly lists 3 new tests required.
+
+**Organization**: Grouped by user story; each story is independently testable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no blocking dependencies)
+- **[Story]**: User story label (US1, US2, US3)
+
+---
+
+## Phase 1: Setup
+
+> No new projects or infrastructure setup required — all changes are additive modifications to the existing `Juice.Messaging.Outbox.Delivery` project.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: `ProcessorPolicyRegistry` is a shared dependency used by both `DeliveryProcessorBuilder` (write path) and `DeliveryPolicyConfiguration` (read path). It MUST exist before any user story work begins.
+
+**⚠️ CRITICAL**: Phases 3–5 cannot begin until this phase is complete.
+
+- [x] T001 Create internal class `ProcessorPolicyRegistry` (`HashSet<string>` wrapper with `Register(key)` and `IsConfigured(key)` methods, plus `GetOrCreateRegistry(IServiceCollection)` static helper using the instance-singleton pattern) in `core/src/Juice.Messaging.Outbox.Delivery/Internal/ProcessorPolicyRegistry.cs`
+
+**Checkpoint**: `ProcessorPolicyRegistry` compiled and available — user story implementation can begin.
+
+---
+
+## Phase 3: User Story 1 — Per-Processor Policy Configuration (Priority: P1) 🎯 MVP
+
+**Goal**: Developers can call `proc.AddDeliveryPolicies(...)` inline when registering a processor. The configured policy takes effect for that processor's delivery loop. Global config-section key-matched entries still outrank processor code policies.
+
+**Independent Test**: Register a processor with `BatchSize = 50` and no global config; verify `IDeliveryPolicyResolver.GetPolicyAsync` returns `BatchSize = 50`. Also register a matching global config-section key entry with `BatchSize = 30` and verify `30` wins.
+
+### Implementation for User Story 1
+
+- [x] T002 [US1] Add `_sectionConfigures` (`List<IConfigurationSection>`) and `_policyConfigures` (`List<Action<DeliveryPolicyOptions>>`) storage fields to `DeliveryProcessorBuilder` in `core/src/Juice.Messaging.Outbox.Delivery/Processing/DeliveryProcessorBuilder.cs`
+
+- [x] T003 [US1] Add `AddDeliveryPolicies(IConfigurationSection policies)` method to `DeliveryProcessorBuilder` — appends to `_sectionConfigures` and returns `this`; add `AddDeliveryPolicies(Action<DeliveryPolicyOptions> configure)` method — appends to `_policyConfigures` and returns `this`; in `core/src/Juice.Messaging.Outbox.Delivery/Processing/DeliveryProcessorBuilder.cs`
+
+- [x] T004 [US1] Add `internal void RegisterProcessorPolicies<TContext>(IServiceCollection services)` method to `DeliveryProcessorBuilder` in `core/src/Juice.Messaging.Outbox.Delivery/Processing/DeliveryProcessorBuilder.cs`: if no configures stored → return (no-op); else compute `processorKey = $"{_publisher}:{typeof(TContext).Name}"`, get-or-create `ProcessorPolicyRegistry` via static helper and call `registry.Register(processorKey)`, then call `services.Configure<DeliveryPolicyOptions>(processorKey, section)` for each `_sectionConfigures` entry and `services.Configure<DeliveryPolicyOptions>(processorKey, action)` for each `_policyConfigures` entry
+
+- [x] T005 [P] [US1] Update `DeliveryBuilder.AddDeliveryProcessor<TContext>(string publisher, Action<DeliveryProcessorBuilder>? configure)` in `core/src/Juice.Messaging.Outbox.Delivery/DeliveryBuilder.cs`: after `configure?.Invoke(builder)` and before `_services.AddHostedService(...)`, call `builder.RegisterProcessorPolicies<TContext>(_services)`
+
+- [x] T006 [P] [US1] Update `DeliveryBuilder.AddDeliveryProcessor<TContext>(string publisher, params string[] intents)` in `core/src/Juice.Messaging.Outbox.Delivery/DeliveryBuilder.cs`: after `builder.WithIntents(intents)` and before `_services.AddHostedService(...)`, call `builder.RegisterProcessorPolicies<TContext>(_services)`
+
+- [x] T007 [US1] Update `DeliveryPolicyConfiguration` constructor in `core/src/Juice.Messaging.Outbox.Delivery/Internal/DeliveryPolicyConfiguration.cs` to accept two new optional parameters: `ProcessorPolicyRegistry? processorRegistry = null` and `IOptionsMonitor<DeliveryPolicyOptions>? optionsMonitor = null`; store both as private fields
+
+- [x] T008 [US1] In `DeliveryPolicyConfiguration.GetPolicyAsync` in `core/src/Juice.Messaging.Outbox.Delivery/Internal/DeliveryPolicyConfiguration.cs`: after the four existing key-match lookups (`exactKey`, `publisherIntentKey`, `publisherKey`, `intentKey`) and before the `DefaultPolicy` check, insert a processor code policy check: if `_processorRegistry?.IsConfigured($"{context.PublisherKey}:{context.Context}") == true` then get `processorOpts = _optionsMonitor!.Get(processorKey)` and if `processorOpts.DefaultPolicy != null` return `processorOpts.DefaultPolicy.ToPolicy(_options.DefaultPolicy?.ToPolicy())`
+
+- [x] T009 [US1] Add unit test `Processor_Code_Policy_Used_When_No_Global_Key_MatchAsync` in `core/test/Juice.EventBus.Tests/DeliveryPoliciesTest.cs`: register a processor with `BatchSize = 50` via delegate, no global Policies dictionary entries; resolve and assert `policy.BatchSize == 50`
+
+- [x] T010 [US1] Add unit test `Global_Config_Section_Key_Match_Overrides_Processor_Code_PolicyAsync` in `core/test/Juice.EventBus.Tests/DeliveryPoliciesTest.cs`: register processor code policy `BatchSize = 50` AND global config section with key `"rabbitmq:send-pending:TestContext": { BatchSize: 30 }`; resolve and assert `policy.BatchSize == 30`
+
+**Checkpoint**: US1 fully functional — processor inline policies work and global config-section key entries still win.
+
+---
+
+## Phase 4: User Story 2 — Global Fallback When No Processor Policy Exists (Priority: P2)
+
+**Goal**: Processors registered without any `AddDeliveryPolicies` call automatically use the globally configured policies. Zero behavioral change for existing code.
+
+**Independent Test**: Register a processor with no `AddDeliveryPolicies` call; configure global policy with `BatchSize = 20`; verify resolved policy uses `BatchSize = 20`.
+
+### Implementation for User Story 2
+
+> No new implementation code required — the fallback is automatic once Phase 3 is complete (`ProcessorPolicyRegistry.IsConfigured` returns false → existing global lookup runs unchanged).
+
+- [x] T011 [US2] Add unit test `Processor_Without_Code_Policy_Falls_Back_To_GlobalAsync` in `core/test/Juice.EventBus.Tests/DeliveryPoliciesTest.cs`: register a processor via `AddDeliveryProcessor<TestContext>("rabbitmq")` with no policy configure callback; add global policy `BatchSize = 20` via `AddDeliveryPolicies(Action<>)`; resolve `DeliveryContext("rabbitmq", "send-pending", "TestContext")` and assert `policy.BatchSize == 20`
+
+- [x] T012 [US2] Add unit test `Processor_Without_Any_Policy_Uses_Built_In_DefaultsAsync` in `core/test/Juice.EventBus.Tests/DeliveryPoliciesTest.cs`: register a processor with no policy and no global policy; resolve and assert policy matches `DeliveryPolicy.Default` values
+
+**Checkpoint**: US2 verified — global fallback works, existing apps unaffected.
+
+---
+
+## Phase 5: User Story 3 — Processor Policy Overrides Global Partially (Priority: P3)
+
+**Goal**: A processor code policy that sets only some fields inherits unset fields from the global policy. Developers do not need to repeat global settings.
+
+**Independent Test**: Set global `BatchSize = 10` and `Interval = 5s`; register processor with code policy setting only `BatchSize = 50`; verify resolved policy has `BatchSize = 50` and `Interval = 5s`.
+
+### Implementation for User Story 3
+
+> No new implementation code required — the null-coalescing merge via `PolicyConfiguration.ToPolicy(globalDefault)` in T008 already handles partial override.
+
+- [x] T013 [US3] Add unit test `Processor_Code_Policy_Partially_Overrides_Global_Inherits_Rest_Async` in `core/test/Juice.EventBus.Tests/DeliveryPoliciesTest.cs`: set global `DefaultPolicy { BatchSize = 10, Interval = 5s }`; register processor code policy `{ BatchSize = 50 }`; resolve and assert `policy.BatchSize == 50` and `policy.Interval == TimeSpan.FromSeconds(5)`
+
+**Checkpoint**: US3 verified — partial override works correctly via null-coalescing.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [x] T014 [P] Update `specs/009-processor-delivery-policy/research.md` Decision 4 to reflect the corrected resolution order from the `/speckit.clarify` session: global config-section `Policies` key matches (steps 1–4, existing) → processor code `DefaultPolicy` (new, step 5) → global `DefaultPolicy` (step 6) → built-in (step 7); remove the old "check processor at the very beginning" statement
+
+- [x] T015 [P] Update `specs/009-processor-delivery-policy/data-model.md` resolution chain diagram to match the clarified spec: show the two-tier config-section vs. processor-code priority with the `DefaultPolicy` split
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Foundational (Phase 2)**: No dependencies — start immediately
+- **US1 (Phase 3)**: Depends on Phase 2 (T001) ⚠️
+- **US2 (Phase 4)**: Depends on Phase 3 complete (T001–T008)
+- **US3 (Phase 5)**: Depends on Phase 3 complete (T001–T008)
+- **Polish (Phase 6)**: Independent — can run any time after Phase 3
+
+### User Story Dependencies
+
+- **US1 (P1)**: Requires T001 (registry). Core implementation: T002 → T003 → T004 → T005/T006 [P] → T007 → T008 → T009/T010
+- **US2 (P2)**: Requires T001–T008. No new implementation — tests only (T011, T012)
+- **US3 (P3)**: Requires T001–T008. No new implementation — test only (T013)
+
+### Parallel Opportunities Within US1
+
+- T005 and T006 modify the same file (`DeliveryBuilder.cs`) — write both methods in one edit pass
+- T007 and T008 modify the same file (`DeliveryPolicyConfiguration.cs`) — sequential; T008 depends on T007
+- T009 and T010 are separate test methods in the same file — write in one edit pass
+
+---
+
+## Parallel Example: User Story 1
+
+```
+Sequential spine:           T001 → T002 → T003 → T004 → T007 → T008
+                                                  ↓
+Parallel branch (same file):            T005 + T006 (both in DeliveryBuilder.cs)
+                                                  ↓
+Test tasks (same file, one pass):       T009 + T010
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 2: T001 — `ProcessorPolicyRegistry`
+2. Complete Phase 3: T002–T010 — API surface + resolver enhancement + US1 tests
+3. **STOP and VALIDATE**: Call `AddDeliveryProcessor<T>("pub", proc => proc.AddDeliveryPolicies(...))` and verify policy resolution
+4. Ship as MVP — US2 and US3 are validated by US1 infrastructure with zero extra code
+
+### Incremental Delivery
+
+1. T001 → Foundation
+2. T002–T008 → Feature implementation (zero tests yet)
+3. T009–T010 → US1 tests (confirm the feature works)
+4. T011–T012 → US2 tests (confirm backward compatibility)
+5. T013 → US3 test (confirm partial override)
+6. T014–T015 → Spec artifacts updated
+
+### Notes
+
+- US2 and US3 require **no new implementation code** — only new test cases. The implementation from Phase 3 already satisfies all three user stories.
+- T005 and T006 guard with `if (!registry.TryAdd(key)) return this;` already present — `RegisterProcessorPolicies` is idempotent (processor already guarded by `DeliveryProcessorRegistry`).
+- All tests follow the existing `DeliveryPoliciesTest` pattern: in-memory service collection + `BuildServiceProvider()` + `GetRequiredService<IDeliveryPolicyResolver>()`.
+- Tests must use `Async` suffix per codebase convention (see CLAUDE.md).


### PR DESCRIPTION
…ion to 9.5.3

- Add ProcessorPolicyRegistry to track processors with explicit code policies
- Extend DeliveryProcessorBuilder with AddDeliveryPolicies overloads (section + delegate)
- Insert processor code policy as step 5 in DeliveryPolicyConfiguration resolution chain (below global key-matched entries, above global DefaultPolicy)
- RegisterProcessorPolicies<TContext> ensures resolver is available even without global AddDeliveryPolicies call
- Add 5 new tests covering US1/US2/US3 policy resolution scenarios
- Add spec/plan/tasks for feature 009-processor-delivery-policy