### PR TITLE
feat: skip phase-2 delivery re-processing when phase-1 local dispatch…

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     <PackageIconUrl>https://avatars.githubusercontent.com/u/107674950</PackageIconUrl>
     <RepositoryUrl>https://github.com/creatorflow-io/Juice</RepositoryUrl>
 
-    <VersionPrefix>9.6.1</VersionPrefix>
+    <VersionPrefix>9.6.2</VersionPrefix>
     <VersionSuffix>local.$([System.DateTime]::Now.ToString(`yyyyMMdd`)).1</VersionSuffix>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/core/src/Juice.Messaging.Local/DependencyInjection/LocalMessagingBuilderExtensions.cs
+++ b/core/src/Juice.Messaging.Local/DependencyInjection/LocalMessagingBuilderExtensions.cs
@@ -112,11 +112,42 @@ namespace Microsoft.Extensions.DependencyInjection
 
         /// <summary>
         /// Registers the <c>"local"</c> outbox-backed in-process transport publisher.
-        /// <see cref="LocalTransportPublisher"/> is registered as a keyed <see cref="ITransportPublisher"/>
-        /// under the key <c>"local"</c>, scoped per request. The existing
-        /// <c>DeliveryHostedService</c> picks up outbox deliveries with <c>PublisherKey = "local"</c>
-        /// and dispatches them in-process via <see cref="LocalTransportPublisher"/>.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <see cref="LocalTransportPublisher"/> is registered as a keyed <see cref="ITransportPublisher"/>
+        /// under the key <c>"local"</c> (scoped). The background <c>DeliveryHostedService</c> picks up
+        /// outbox deliveries whose <c>PublisherKey</c> is <c>"local"</c> and dispatches them in-process
+        /// via <see cref="LocalTransportPublisher"/>.
+        /// </para>
+        /// <para>
+        /// <b>Full setup required</b> — this method only registers the transport; the complete
+        /// <c>"local"</c> route needs all four pieces:
+        /// <code>
+        /// services.AddMessaging()
+        ///     .AddOutbox()                                  // outbox accumulation
+        ///     .AddLocalPublisher()                          // this method — transport publisher
+        ///     .AddDelivery(d =>
+        ///     {
+        ///         d.AddDeliveryPolicies(_ => { });          // policy resolver
+        ///         d.AddDeliveryProcessor&lt;TContext&gt;("local"); // background delivery loop
+        ///     });
+        /// </code>
+        /// Omitting <c>AddDeliveryProcessor&lt;TContext&gt;("local")</c> means outbox rows are written
+        /// but never picked up — their <c>State</c> stays <c>NotPublished</c> indefinitely.
+        /// </para>
+        /// <para>
+        /// If you only need in-process dispatch without durable persistence, use
+        /// <see cref="AddLocalChannel"/> (<c>"local-channel"</c> route) instead — it requires
+        /// no outbox and no delivery hosted service.
+        /// </para>
+        /// <para>
+        /// <b>INotification dispatch</b>: when the message implements <c>INotification</c>,
+        /// <c>IMediator</c> is resolved from the scope. If it is not registered (i.e.
+        /// <c>services.AddMediatR()</c> was not called) an <see cref="InvalidOperationException"/>
+        /// is thrown at delivery time.
+        /// </para>
+        /// </remarks>
         public static MessagingBuilder AddLocalPublisher(
             this MessagingBuilder builder)
         {

--- a/core/src/Juice.Messaging.Local/Internal/ChannelEnvelope.cs
+++ b/core/src/Juice.Messaging.Local/Internal/ChannelEnvelope.cs
@@ -8,7 +8,17 @@ namespace Juice.Messaging.Local.Internal
     /// (correlation ID, source, etc.) across the channel boundary so the background
     /// service can restore it before dispatch — enabling correct idempotency keys.
     /// </summary>
+    /// <param name="Message">The message to dispatch.</param>
+    /// <param name="Context">Optional message context snapshot captured at enqueue time.</param>
+    /// <param name="LocalDeliveryIds">
+    /// Outbox delivery IDs for <c>"local"</c> route messages. When non-null,
+    /// <see cref="LocalChannelBackgroundService"/> resolves <see cref="Juice.Messaging.Outbox.IOutboxRepository"/>
+    /// and calls <c>MarkAsPublishedAsync</c> for each ID after a successful dispatch,
+    /// preventing the background delivery processor from re-processing already-handled records.
+    /// <c>null</c> for <c>"local-channel"</c> messages (no outbox backing).
+    /// </param>
     internal sealed record ChannelEnvelope(
         IMessage Message,
-        MessageContextData? Context);
+        MessageContextData? Context,
+        IReadOnlyList<Guid>? LocalDeliveryIds = null);
 }

--- a/core/src/Juice.Messaging.Local/Internal/LocalChannelBackgroundService.cs
+++ b/core/src/Juice.Messaging.Local/Internal/LocalChannelBackgroundService.cs
@@ -3,6 +3,7 @@ using System.Threading.Channels;
 using Juice.EventBus.Subscriptions;
 using Juice.MediatR;
 using Juice.Messaging.Integrations;
+using Juice.Messaging.Outbox;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -99,6 +100,7 @@ namespace Juice.Messaging.Local.Internal
                         using var scope = _scopeFactory.CreateScope();
                         var sp = scope.ServiceProvider;
 
+                        var dispatchSucceeded = true;
                         if (message is INotification notification)
                         {
                             _logger.LogDebug("Dispatching INotification {MessageType}", message.GetType().Name);
@@ -110,7 +112,8 @@ namespace Juice.Messaging.Local.Internal
                             _logger.LogDebug("Dispatching IIntegrationEvent {MessageType}", message.GetType().Name);
                             var dispatcher = sp.GetRequiredService<IntegrationEventDispatcher>();
                             var subsManager = sp.GetKeyedService<ISubscriptionsManager>("local");
-                            await LocalDispatchHelper.DispatchIntegrationEventAsync(sp, dispatcher, subsManager, integrationEvent, CancellationToken.None);
+                            var result = await LocalDispatchHelper.DispatchIntegrationEventAsync(sp, dispatcher, subsManager, integrationEvent, CancellationToken.None);
+                            dispatchSucceeded = result != Integrations.EventDispatchResult.Failure;
                         }
                         else
                         {
@@ -118,10 +121,47 @@ namespace Juice.Messaging.Local.Internal
                                 message.GetType().Name);
                         }
 
+                        // For "local" route messages, mark the outbox delivery records as Published
+                        // so the background delivery processor does not re-process them.
+                        // Only mark Published when dispatch succeeded — if any handler failed,
+                        // the records remain NotPublished and the delivery processor will retry.
+                        // If marking fails (e.g. DB unavailable), the records remain NotPublished
+                        // and the delivery processor will pick them up on its next cycle.
+                        if (dispatchSucceeded && envelope.LocalDeliveryIds is { Count: > 0 })
+                        {
+                            var repo = sp.GetService<IOutboxRepository>();
+                            if (repo != null)
+                            {
+                                try
+                                {
+                                    foreach (var deliveryId in envelope.LocalDeliveryIds)
+                                    {
+                                        await repo.MarkAsPublishedAsync(deliveryId, CancellationToken.None);
+                                    }
+                                }
+                                catch (Exception markEx)
+                                {
+                                    _logger.LogWarning(markEx,
+                                        "Failed to mark local delivery Published for message {MessageId} — " +
+                                        "delivery will be retried by background processor",
+                                        message.MessageId);
+                                }
+                            }
+                        }
+
                         stopwatch.Stop();
                         LocalChannelMetrics.RecordDeliveryLatency(PublisherKey, stopwatch.Elapsed);
-                        LocalChannelMetrics.IncrementDeliverySuccess(PublisherKey);
-                        _logger.LogDebug("Dispatched {MessageType} in {Elapsed}ms", message.GetType().Name, stopwatch.ElapsedMilliseconds);
+                        if (dispatchSucceeded)
+                        {
+                            LocalChannelMetrics.IncrementDeliverySuccess(PublisherKey);
+                            _logger.LogDebug("Dispatched {MessageType} in {Elapsed}ms", message.GetType().Name, stopwatch.ElapsedMilliseconds);
+                        }
+                        else
+                        {
+                            LocalChannelMetrics.IncrementDeliveryFailure(PublisherKey, nameof(EventDispatchResult.Failure));
+                            _logger.LogWarning("Dispatch of {MessageType} (id={MessageId}) failed — one or more handlers returned a failure result. Delivery remains NotPublished for retry.",
+                                message.GetType().Name, message.MessageId);
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/core/src/Juice.Messaging.Local/Internal/LocalChannelMessagePublisher.cs
+++ b/core/src/Juice.Messaging.Local/Internal/LocalChannelMessagePublisher.cs
@@ -39,9 +39,15 @@ namespace Juice.Messaging.Local.Internal
                 : null;
         }
 
+        public ValueTask PublishAsync(IMessage message, MessageContextData? context, IReadOnlyList<Guid>? localDeliveryIds, CancellationToken cancellationToken = default)
+            => PublishAsync(message, context, cancellationToken, localDeliveryIds);
+
         public async ValueTask PublishAsync(IMessage message, MessageContextData? context, CancellationToken cancellationToken = default)
+            => await PublishAsync(message, context, cancellationToken, localDeliveryIds: null);
+
+        private async ValueTask PublishAsync(IMessage message, MessageContextData? context, CancellationToken cancellationToken, IReadOnlyList<Guid>? localDeliveryIds)
         {
-            var envelope = new ChannelEnvelope(message, context);
+            var envelope = new ChannelEnvelope(message, context, localDeliveryIds);
 
             if (_channelWriter.TryWrite(envelope))
             {

--- a/core/src/Juice.Messaging.Local/Internal/LocalChannelMetrics.cs
+++ b/core/src/Juice.Messaging.Local/Internal/LocalChannelMetrics.cs
@@ -40,6 +40,11 @@ namespace Juice.Messaging.Local.Internal
                 "channel_dropped_total",
                 description: "Messages dropped because the local channel was full");
 
+        private static readonly Counter<long> Phase1FallbackCounter =
+            _meter.CreateCounter<long>(
+                "local_delivery_phase1_fallback_total",
+                description: "Deliveries for the 'local' route that reached the background delivery processor despite being dispatched in phase 1 — indicates phase 1 did not mark the outbox record Published (e.g. DB unavailable during marking)");
+
         // Registered lazily when the channel is created so the gauge holds a live reference.
         private static bool _queueDepthRegistered;
 
@@ -69,6 +74,13 @@ namespace Juice.Messaging.Local.Internal
         {
             DeliveryLatencyHistogram.Record(
                 elapsed.TotalMilliseconds,
+                new KeyValuePair<string, object?>("publisher", publisherKey));
+        }
+
+        public static void IncrementPhase1Fallback(string publisherKey)
+        {
+            Phase1FallbackCounter.Add(
+                1,
                 new KeyValuePair<string, object?>("publisher", publisherKey));
         }
 

--- a/core/src/Juice.Messaging.Local/Internal/LocalTransportPublisher.cs
+++ b/core/src/Juice.Messaging.Local/Internal/LocalTransportPublisher.cs
@@ -24,20 +24,17 @@ namespace Juice.Messaging.Local.Internal
         private readonly IMessageSerializer _serializer;
         private readonly IServiceScopeFactory _scopeFactory;
         private readonly IntegrationEventDispatcher _dispatcher;
-        private readonly IMediator _mediator;
         private readonly ILogger<LocalTransportPublisher> _logger;
 
         public LocalTransportPublisher(
             IMessageSerializer serializer,
             IServiceScopeFactory scopeFactory,
             IntegrationEventDispatcher dispatcher,
-            IMediator mediator,
             ILogger<LocalTransportPublisher> logger)
         {
             _serializer = serializer;
             _scopeFactory = scopeFactory;
             _dispatcher = dispatcher;
-            _mediator = mediator;
             _logger = logger;
         }
 
@@ -146,17 +143,34 @@ namespace Juice.Messaging.Local.Internal
 
             try
             {
+                using var scope = _scopeFactory.CreateScope();
                 if (message is INotification notification)
                 {
-                    await LocalDispatchHelper.DispatchNotificationAsync(_mediator, notification, cancellationToken);
+                    var mediator = scope.ServiceProvider.GetService<IMediator>()
+                        ?? throw new InvalidOperationException(
+                            $"IMediator is not registered. Call services.AddMediatR() to dispatch " +
+                            $"INotification messages through the '{Key}' transport publisher.");
+                    await LocalDispatchHelper.DispatchNotificationAsync(mediator, notification, cancellationToken);
                 }
                 else if (message is IIntegrationEvent integrationEvent)
                 {
-                    using var scope = _scopeFactory.CreateScope();
                     var subsManager = scope.ServiceProvider.GetKeyedService<ISubscriptionsManager>("local");
                     var result = await LocalDispatchHelper.DispatchIntegrationEventAsync(
                         scope.ServiceProvider, _dispatcher, subsManager, integrationEvent, cancellationToken);
-                    if (result == Integrations.EventDispatchResult.Failure)
+                    if (result == Integrations.EventDispatchResult.Duplicated)
+                    {
+                        // Phase 1 (LocalChannelBackgroundService) already processed this event but
+                        // did not mark the outbox record Published (e.g. DB was unavailable during marking).
+                        // The delivery processor picked it up as NotPublished and called this publisher.
+                        // Log a warning so operators can distinguish this fallback from normal delivery.
+                        _logger.LogWarning(
+                            "Event {EventName} (MessageId={MessageId}) was already processed in phase 1 immediate dispatch " +
+                            "but its outbox delivery was not marked Published — completing via phase 2 fallback. PublisherKey={PublisherKey}.",
+                            integrationEvent.EventName, integrationEvent.MessageId, Key);
+                        LocalChannelMetrics.IncrementPhase1Fallback(Key);
+                        // Do not throw — DeliveryProcessor marks the record Published via the normal path.
+                    }
+                    else if (result == Integrations.EventDispatchResult.Failure)
                     {
                         throw new InvalidOperationException(
                             $"One or more handlers failed to process event {integrationEvent.GetType().Name} (MessageId={integrationEvent.MessageId})");

--- a/core/src/Juice.Messaging.Local/Juice.Messaging.Local.csproj
+++ b/core/src/Juice.Messaging.Local/Juice.Messaging.Local.csproj
@@ -18,6 +18,7 @@
         <ProjectReference Include="..\Juice.EventBus\Juice.EventBus.csproj" />
         <ProjectReference Include="..\Juice.MediatR\Juice.MediatR.csproj" />
         <ProjectReference Include="..\Juice.Messaging\Juice.Messaging.csproj" />
+        <ProjectReference Include="..\Juice.Messaging.Outbox\Juice.Messaging.Outbox.csproj" />
     </ItemGroup>
 
 </Project>

--- a/core/src/Juice.Messaging.Outbox.Delivery/DeliveryBuilder.cs
+++ b/core/src/Juice.Messaging.Outbox.Delivery/DeliveryBuilder.cs
@@ -4,6 +4,7 @@ using Juice.Messaging.Outbox.Delivery.Registry;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Juice.Messaging.Outbox.Delivery
@@ -39,7 +40,12 @@ namespace Juice.Messaging.Outbox.Delivery
 
             builder.RegisterProcessorPolicies<TContext>();
 
-            _services.AddHostedService(sp => builder.BuildHostedService<TContext>(sp));
+            // Use Add instead of AddHostedService to bypass TryAddEnumerable deduplication.
+            // AddHostedService deduplicates by (IHostedService, ImplementationType), so two
+            // AddDeliveryProcessor<TContext> calls with the same TContext but different publishers
+            // would both produce CompositeDeliveryHostedService<TContext> and the second would be
+            // silently dropped.
+            _services.Add(ServiceDescriptor.Singleton<IHostedService>(sp => builder.BuildHostedService<TContext>(sp)));
             return this;
         }
 
@@ -59,7 +65,8 @@ namespace Juice.Messaging.Outbox.Delivery
 
             builder.RegisterProcessorPolicies<TContext>();
 
-            _services.AddHostedService(sp => builder.BuildHostedService<TContext>(sp));
+            // Use Add instead of AddHostedService — see comment in the other overload.
+            _services.Add(ServiceDescriptor.Singleton<IHostedService>(sp => builder.BuildHostedService<TContext>(sp)));
             return this;
         }
 

--- a/core/src/Juice.Messaging.Outbox.Delivery/Processing/DeliveryProcessor.cs
+++ b/core/src/Juice.Messaging.Outbox.Delivery/Processing/DeliveryProcessor.cs
@@ -54,6 +54,16 @@ namespace Juice.Messaging.Outbox.Delivery.Processing
             }
         }
 
+        /// <summary>
+        /// Processes a single outbox delivery through the full InProgress → Published/Failed cycle.
+        /// <para>
+        /// For the <c>"local"</c> publisher: if phase 1 (immediate dispatch via
+        /// <c>LocalChannelBackgroundService</c>) succeeded and marked the record <c>Published</c>,
+        /// <c>SendPendingIntent</c> never retrieves it (it filters to <c>NotPublished</c> only),
+        /// so this method is not called for those records. This path handles phase 1 failures,
+        /// crash-recovery scenarios, and any case where the outbox record was not closed by phase 1.
+        /// </para>
+        /// </summary>
         private async Task ProcessSingleDeliveryAsync(OutboxDelivery delivery, CancellationToken cancellationToken)
         {
             using var _ = _logger.BeginScope(new Dictionary<string, object?> { { "TraceId", delivery.DeliveryId } });

--- a/core/src/Juice.Messaging.Outbox/Internal/OutboxEventService.cs
+++ b/core/src/Juice.Messaging.Outbox/Internal/OutboxEventService.cs
@@ -18,6 +18,11 @@ namespace Juice.Messaging.Outbox.Internal
         private readonly IMessageSerializer _serializer;
         private readonly ITenantAccessor? _tenantAccessor;
 
+        // Delivery IDs created during the most recent SaveEventsAsync call,
+        // keyed by (messageId, publisherKey). Reset at the start of each SaveEventsAsync
+        // so callers always see the latest snapshot.
+        private Dictionary<(Guid messageId, string publisherKey), List<Guid>> _pendingDeliveryIds = new();
+
         public OutboxEventService(IOutboxRepository<TContext> eventLogService
             , IMessagePublishingPolicy publishingPolicy
             , IMessageSerializer serializer
@@ -44,6 +49,9 @@ namespace Juice.Messaging.Outbox.Internal
             return ValueTask.CompletedTask;
         }
 
+        public IReadOnlyList<Guid> GetPendingDeliveryIds(Guid messageId, string publisherKey)
+            => _pendingDeliveryIds.TryGetValue((messageId, publisherKey), out var ids) ? ids : [];
+
         public async ValueTask SaveEventsAsync(Guid? transactionId, CancellationToken cancellationToken)
         {
             if (_logger.IsEnabled(LogLevel.Debug))
@@ -52,6 +60,7 @@ namespace Juice.Messaging.Outbox.Internal
             }
             _timeTracker?.BeginScope("Saving integration events");
 
+            _pendingDeliveryIds = new Dictionary<(Guid, string), List<Guid>>();
             var events = new List<OutboxEvent>();
             var ctx = MessageContext.Current;
 
@@ -96,12 +105,26 @@ namespace Juice.Messaging.Outbox.Internal
                                     },
                     TransactionId = transactionId?.ToString(),
                     TenantId = _tenantAccessor?.Tenant?.Id,
-                    Deliveries = [.. routes.Select(route => new OutboxDelivery
+                    Deliveries = [.. routes.Select(route =>
                     {
-                        EventId = message.MessageId,
-                        PublisherKey = route.PublisherKey,
-                        Destination = route.Destination,
-                        RoutingKey = route.RoutingKey
+                        var delivery = new OutboxDelivery
+                        {
+                            EventId = message.MessageId,
+                            PublisherKey = route.PublisherKey,
+                            Destination = route.Destination,
+                            RoutingKey = route.RoutingKey,
+                            CreationTime = DateTimeOffset.UtcNow
+                        };
+                        // Track delivery IDs per (messageId, publisherKey) so callers can retrieve
+                        // the exact delivery for a specific message via GetPendingDeliveryIds.
+                        var key = (message.MessageId, route.PublisherKey);
+                        if (!_pendingDeliveryIds.TryGetValue(key, out var idList))
+                        {
+                            idList = new List<Guid>();
+                            _pendingDeliveryIds[key] = idList;
+                        }
+                        idList.Add(delivery.DeliveryId);
+                        return delivery;
                     })]
                 });
             }

--- a/core/src/Juice.Messaging/Internal/MessageServiceT.cs
+++ b/core/src/Juice.Messaging/Internal/MessageServiceT.cs
@@ -132,10 +132,12 @@ namespace Juice.Messaging.Internal
                 // For "local" routes, enqueue to the in-memory channel for immediate
                 // best-effort dispatch. The outbox entry remains for durability —
                 // DeliveryHostedService will pick it up on retry if this dispatch fails.
-                // IntegrationEventDispatcher idempotency deduplicates if both succeed.
+                // Delivery IDs are passed so LocalChannelBackgroundService can mark them
+                // Published after a successful dispatch, preventing phase-2 re-processing.
                 if (hasLocalOutbox)
                 {
-                    await PublishLocalMessageAsync(message, true, cancellationToken);
+                    var localDeliveryIds = _outboxService.GetPendingDeliveryIds(message.MessageId, "local");
+                    await PublishLocalMessageAsync(message, true, localDeliveryIds.Count > 0 ? localDeliveryIds : null, cancellationToken);
                 }
             }
         }
@@ -152,7 +154,10 @@ namespace Juice.Messaging.Internal
             });
         }
 
-        private async Task PublishLocalMessageAsync(IMessage message, bool hasOutboxRoutes, CancellationToken cancellationToken)
+        private Task PublishLocalMessageAsync(IMessage message, bool hasOutboxRoutes, CancellationToken cancellationToken)
+            => PublishLocalMessageAsync(message, hasOutboxRoutes, localDeliveryIds: null, cancellationToken);
+
+        private async Task PublishLocalMessageAsync(IMessage message, bool hasOutboxRoutes, IReadOnlyList<Guid>? localDeliveryIds, CancellationToken cancellationToken)
         {
             var contextSnapshot = MessageContext.IsInitialized
                 ? MessageContext.Current
@@ -171,7 +176,7 @@ namespace Juice.Messaging.Internal
                 }
                 return;
             }
-            await messagePublisher.PublishAsync(message, contextSnapshot, cancellationToken);
+            await messagePublisher.PublishAsync(message, contextSnapshot, localDeliveryIds, cancellationToken);
         }
     }
 }

--- a/core/src/Juice.Messaging/Outbox/IOutboxService.cs
+++ b/core/src/Juice.Messaging/Outbox/IOutboxService.cs
@@ -23,6 +23,14 @@
     }
     public interface IOutboxService<out TContext> : IOutboxService
     {
-
+        /// <summary>
+        /// Returns the outbox delivery IDs created for the given <paramref name="messageId"/>
+        /// and <paramref name="publisherKey"/> during the most recent
+        /// <see cref="IOutboxService.SaveEventsAsync"/> call.
+        /// Returns an empty list if no matching deliveries were created, or if
+        /// <see cref="IOutboxService.SaveEventsAsync"/> has not yet been called.
+        /// This snapshot is reset at the start of each new <see cref="IOutboxService.SaveEventsAsync"/> cycle.
+        /// </summary>
+        IReadOnlyList<Guid> GetPendingDeliveryIds(Guid messageId, string publisherKey);
     }
 }

--- a/core/src/Juice.Messaging/Publishing/IMessagePublisher.cs
+++ b/core/src/Juice.Messaging/Publishing/IMessagePublisher.cs
@@ -12,6 +12,17 @@ namespace Juice.Messaging.Publishing
         /// <param name="context"></param>
         /// <param name="cancellationToken"></param>
         ValueTask PublishAsync(IMessage message, MessageContextData? context, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Publish a message with optional outbox delivery IDs. When <paramref name="localDeliveryIds"/>
+        /// is non-null, implementations that support in-process local delivery (e.g. the
+        /// <c>"local-channel"</c> publisher) can forward the IDs so the dispatch handler can
+        /// mark the corresponding outbox records as <c>Published</c> after successful dispatch.
+        /// The default implementation ignores <paramref name="localDeliveryIds"/> and delegates
+        /// to <see cref="PublishAsync(IMessage, MessageContextData?, CancellationToken)"/>.
+        /// </summary>
+        virtual ValueTask PublishAsync(IMessage message, MessageContextData? context, IReadOnlyList<Guid>? localDeliveryIds, CancellationToken cancellationToken = default)
+            => PublishAsync(message, context, cancellationToken);
     }
 
 }

--- a/core/test/Juice.Messaging.Local.Tests/DefaultOutboxContextTests.cs
+++ b/core/test/Juice.Messaging.Local.Tests/DefaultOutboxContextTests.cs
@@ -199,6 +199,8 @@ namespace Juice.Messaging.Local.Tests
                 _tracker.SaveEventsCalled = true;
                 return ValueTask.CompletedTask;
             }
+
+            public IReadOnlyList<Guid> GetPendingDeliveryIds(Guid messageId, string publisherKey) => [];
         }
 
         private sealed class FakeOutboxService : IOutboxService<FakeDbContext>
@@ -206,6 +208,7 @@ namespace Juice.Messaging.Local.Tests
             public ValueTask AddEventAsync(IMessage message) => ValueTask.CompletedTask;
             public ValueTask SaveEventsAsync(Guid? transactionId, CancellationToken cancellationToken = default)
                 => ValueTask.CompletedTask;
+            public IReadOnlyList<Guid> GetPendingDeliveryIds(Guid messageId, string publisherKey) => [];
         }
 
         private sealed class FixedRoutePolicy(string publisherKey, string destination)

--- a/core/test/Juice.Messaging.Local.Tests/LocalDeliverySkipTests.cs
+++ b/core/test/Juice.Messaging.Local.Tests/LocalDeliverySkipTests.cs
@@ -1,0 +1,250 @@
+using System.Collections.Concurrent;
+using FluentAssertions;
+using Juice.Messaging;
+using Juice.Messaging.Local;
+using Juice.Messaging.Outbox;
+using Juice.Messaging.Outbox.EF;
+using Juice.Messaging.Policies;
+using Juice.XUnit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace Juice.Messaging.Local.Tests
+{
+    /// <summary>
+    /// Integration tests for the two-phase local delivery skip feature.
+    /// <para>
+    /// US1 (T015): After phase 1 immediate dispatch succeeds, <see cref="LocalChannelBackgroundService"/>
+    /// calls <see cref="IOutboxRepository.MarkAsPublishedAsync"/> for the outbox delivery ID — so the
+    /// background delivery processor never sees a <c>NotPublished</c> record.
+    /// </para>
+    /// <para>
+    /// US2 (T016): When phase 1 dispatch fails (handler throws), the delivery ID is NOT marked
+    /// <c>Published</c>. The record remains <c>NotPublished</c> for the background delivery processor
+    /// to retry.
+    /// </para>
+    /// </summary>
+    public class LocalDeliverySkipTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public LocalDeliverySkipTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // T015 — US1 happy path: phase 1 success marks delivery Published
+        // ─────────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// When a "local" route message is published and the handler succeeds,
+        /// <see cref="LocalChannelBackgroundService"/> must call
+        /// <see cref="IOutboxRepository.MarkAsPublishedAsync"/> with the delivery ID
+        /// returned by <see cref="IOutboxService{TContext}.GetPendingDeliveryIds"/>.
+        /// </summary>
+        [IgnoreOnCIFact]
+        [InitializeMessageContext]
+        public async Task Phase1_Success_MarksDeliveryPublishedAsync()
+        {
+            var deliveryId = Guid.NewGuid();
+            var handlerSignal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var markedPublished = new ConcurrentBag<Guid>();
+
+            var provider = BuildServices(
+                deliveryId: deliveryId,
+                outboxRepo: new SpyOutboxRepository(markedPublished),
+                configureServices: services =>
+                {
+                    services.AddTransient<IIntegrationEventHandler<LocalTestEvent>>(
+                        _ => new SignalingHandler(handlerSignal));
+                });
+
+            using var cts = new CancellationTokenSource();
+            var hostedServices = provider.GetServices<IHostedService>().ToList();
+            foreach (var hs in hostedServices) await hs.StartAsync(cts.Token);
+
+            using var scope = provider.CreateScope();
+            var svc = scope.ServiceProvider.GetRequiredService<IMessageService>();
+            await svc.PublishAsync(new LocalTestEvent());
+
+            // Wait for handler to complete
+            await handlerSignal.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // Give the background service a moment to call MarkAsPublishedAsync after dispatch
+            await Task.Delay(200);
+
+            markedPublished.Should().Contain(deliveryId,
+                "LocalChannelBackgroundService must call MarkAsPublishedAsync with the outbox delivery ID " +
+                "after a successful phase 1 dispatch");
+
+            cts.Cancel();
+            foreach (var hs in hostedServices) await hs.StopAsync(CancellationToken.None);
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // T016 — US2 failure fallback: phase 1 failure leaves delivery NotPublished
+        // ─────────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// When a "local" route message is published and the handler throws,
+        /// <see cref="LocalChannelBackgroundService"/> must NOT call
+        /// <see cref="IOutboxRepository.MarkAsPublishedAsync"/> — the delivery record
+        /// stays <c>NotPublished</c> so the background processor can retry it.
+        /// </summary>
+        [IgnoreOnCIFact]
+        [InitializeMessageContext]
+        public async Task Phase1_Failure_DoesNotMarkDeliveryPublishedAsync()
+        {
+            var deliveryId = Guid.NewGuid();
+            var handlerInvokedSignal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var markedPublished = new ConcurrentBag<Guid>();
+
+            var provider = BuildServices(
+                deliveryId: deliveryId,
+                outboxRepo: new SpyOutboxRepository(markedPublished),
+                configureServices: services =>
+                {
+                    services.AddTransient<IIntegrationEventHandler<LocalTestEvent>>(
+                        _ => new ThrowingHandler(handlerInvokedSignal));
+                });
+
+            using var cts = new CancellationTokenSource();
+            var hostedServices = provider.GetServices<IHostedService>().ToList();
+            foreach (var hs in hostedServices) await hs.StartAsync(cts.Token);
+
+            using var scope = provider.CreateScope();
+            var svc = scope.ServiceProvider.GetRequiredService<IMessageService>();
+            await svc.PublishAsync(new LocalTestEvent());
+
+            // Wait for handler to be invoked (it will throw, but we still need to wait)
+            await handlerInvokedSignal.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // Allow background service to finish the error path
+            await Task.Delay(300);
+
+            markedPublished.Should().NotContain(deliveryId,
+                "LocalChannelBackgroundService must NOT mark the delivery Published when the handler throws — " +
+                "the record must remain NotPublished for the background processor to retry");
+
+            cts.Cancel();
+            foreach (var hs in hostedServices) await hs.StopAsync(CancellationToken.None);
+        }
+
+        // ─── Helpers ──────────────────────────────────────────────────────────
+
+        private IServiceProvider BuildServices(
+            Guid deliveryId,
+            SpyOutboxRepository outboxRepo,
+            Action<IServiceCollection>? configureServices = null)
+        {
+            var services = new ServiceCollection();
+            services.AddLogging(b => b.SetMinimumLevel(LogLevel.Debug).AddTestOutputLogger(_output));
+            services.AddMediatR();
+
+            var messaging = services.AddMessaging();
+            messaging.AddLocalChannel();
+            messaging.AddIdempotencyInMemory();
+            messaging.AddDefaultMessageService(_ => { });
+
+            // Route to "local" (outbox-backed) publisher
+            services.AddSingleton<IMessagePublishingPolicy>(
+                new FixedRoutePolicy("local", string.Empty));
+
+            // Override outbox service with a spy that returns the known delivery ID
+            services.AddScoped<IOutboxService<DefaultOutboxContext>>(
+                _ => new DeliveryIdStubOutboxService(deliveryId));
+
+            // Register a spy IOutboxRepository that records MarkAsPublishedAsync calls
+            services.AddScoped<IOutboxRepository>(_ => outboxRepo);
+
+            configureServices?.Invoke(services);
+            return services.BuildServiceProvider();
+        }
+
+        // ─── Supporting types ─────────────────────────────────────────────────
+
+        private sealed record LocalTestEvent : IntegrationEvent;
+
+        private sealed class FixedRoutePolicy(string publisherKey, string destination)
+            : IMessagePublishingPolicy
+        {
+            public ValueTask<IReadOnlyCollection<PublishRoute>> ResolveAsync(PolicyResolveContext context)
+            {
+                IReadOnlyCollection<PublishRoute> routes = [new PublishRoute(publisherKey, destination)];
+                return ValueTask.FromResult(routes);
+            }
+        }
+
+        /// <summary>
+        /// Stub outbox service that always reports a single pre-known delivery ID
+        /// for the <c>"local"</c> publisher key, simulating what <see cref="OutboxEventService"/>
+        /// does after a real <c>SaveEventsAsync</c> call.
+        /// </summary>
+        private sealed class DeliveryIdStubOutboxService(Guid deliveryId) : IOutboxService<DefaultOutboxContext>
+        {
+            private Guid _lastMessageId;
+
+            public ValueTask AddEventAsync(IMessage message)
+            {
+                _lastMessageId = message.MessageId;
+                return ValueTask.CompletedTask;
+            }
+
+            public ValueTask SaveEventsAsync(Guid? transactionId, CancellationToken cancellationToken = default)
+                => ValueTask.CompletedTask;
+
+            public IReadOnlyList<Guid> GetPendingDeliveryIds(Guid messageId, string publisherKey)
+                => messageId == _lastMessageId && publisherKey == "local" ? [deliveryId] : [];
+        }
+
+        /// <summary>
+        /// Spy <see cref="IOutboxRepository"/> that records each delivery ID passed to
+        /// <see cref="IOutboxRepository.MarkAsPublishedAsync"/> so tests can assert whether marking occurred.
+        /// </summary>
+        private sealed class SpyOutboxRepository(ConcurrentBag<Guid> markedPublished) : IOutboxRepository
+        {
+            public ValueTask MarkAsPublishedAsync(Guid deliveryId, CancellationToken cancellationToken = default)
+            {
+                markedPublished.Add(deliveryId);
+                return ValueTask.CompletedTask;
+            }
+
+            public ValueTask<int> MarkAsInProgressAsync(Guid deliveryId, CancellationToken cancellationToken = default)
+                => ValueTask.FromResult(1);
+
+            public ValueTask MarkAsFailedAsync(Guid deliveryId, string error, DateTimeOffset? nextAttempt, CancellationToken cancellationToken = default)
+                => ValueTask.CompletedTask;
+
+            public ValueTask MarkAsSkippedAsync(Guid deliveryId, string reason, CancellationToken cancellationToken = default)
+                => ValueTask.CompletedTask;
+
+            public ValueTask SaveEventsAsync(OutboxEvent[] @event, CancellationToken cancellationToken = default)
+                => ValueTask.CompletedTask;
+
+            public void Dispose() { }
+        }
+
+        private sealed class SignalingHandler(TaskCompletionSource<bool> signal)
+            : IIntegrationEventHandler<LocalTestEvent>
+        {
+            public Task HandleAsync(LocalTestEvent @event)
+            {
+                signal.TrySetResult(true);
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class ThrowingHandler(TaskCompletionSource<bool> invokedSignal)
+            : IIntegrationEventHandler<LocalTestEvent>
+        {
+            public Task HandleAsync(LocalTestEvent @event)
+            {
+                invokedSignal.TrySetResult(true);
+                throw new InvalidOperationException("Simulated phase 1 handler failure");
+            }
+        }
+    }
+}

--- a/core/test/Juice.Messaging.Local.Tests/TransactionAwareTests.cs
+++ b/core/test/Juice.Messaging.Local.Tests/TransactionAwareTests.cs
@@ -325,6 +325,8 @@ namespace Juice.Messaging.Local.Tests
                 _tracker.SaveEventsCalled = true;
                 return ValueTask.CompletedTask;
             }
+
+            public IReadOnlyList<Guid> GetPendingDeliveryIds(Guid messageId, string publisherKey) => [];
         }
 
         private sealed class FixedRoutePolicy(string publisherKey, string destination)

--- a/specs/010-local-delivery-skip/checklists/requirements.md
+++ b/specs/010-local-delivery-skip/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Skip Already-Processed Local Deliveries in Phase 2
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-14  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Ready for `/speckit.plan`.

--- a/specs/010-local-delivery-skip/data-model.md
+++ b/specs/010-local-delivery-skip/data-model.md
@@ -1,0 +1,165 @@
+# Data Model: Skip Already-Processed Local Deliveries in Phase 2
+
+**Branch**: `010-local-delivery-skip`  
+**Phase**: 1 — Design  
+**Date**: 2026-04-14
+
+---
+
+## Existing Entities (unchanged)
+
+### OutboxDelivery
+
+No changes to the entity. The `Published` state already exists and is the correct terminal state for a phase-1-completed delivery. The `ProcessedOn` field is set to the timestamp of whichever phase completed the delivery.
+
+```
+OutboxDelivery
+├── DeliveryId : Guid          (immutable, PK)
+├── EventId    : Guid          (FK → OutboxEvent)
+├── PublisherKey : string      (e.g. "local", "rabbitmq")
+├── Destination  : string
+├── RoutingKey   : string?
+├── CreationTime : DateTimeOffset
+├── State        : DeliveryState   ← published by phase 1 or phase 2
+├── RetryCount   : int
+├── ProcessedOn  : DateTimeOffset? ← set by whichever phase completes delivery
+├── LastError    : string?
+└── NextAttemptOn: DateTimeOffset?
+
+DeliveryState:
+  NotPublished = 0  (initial)
+  InProgress   = 1  (claimed by phase 2)
+  Published    = 2  (terminal — delivered by phase 1 OR phase 2)
+  Failed       = 3  (phase 2 retry pending)
+  Skipped      = 4  (destination unavailable / event obsolete — NOT used here)
+```
+
+---
+
+## Modified: `ChannelEnvelope`
+
+**Location**: `core/src/Juice.Messaging.Local/Internal/ChannelEnvelope.cs`
+
+Add an optional list of outbox delivery IDs. When non-null and non-empty, `LocalChannelBackgroundService` knows there are outbox deliveries to mark `Published` after a successful dispatch. This is a pure data field — no behaviour/closure is embedded in the envelope.
+
+```
+ChannelEnvelope
+├── Message          : IMessage                (existing)
+├── Context          : MessageContextData?      (existing)
+└── LocalDeliveryIds : IReadOnlyList<Guid>?    ← NEW (null for "local-channel"; delivery IDs for "local" route)
+```
+
+**Behaviour rules**:
+- `LocalDeliveryIds` is `null` for `"local-channel"` messages (no outbox backing).
+- `LocalDeliveryIds` is set for `"local"` route messages; populated from `IOutboxService.GetPendingDeliveryIds("local")` immediately after `SaveEventsAsync`.
+- `LocalChannelBackgroundService` checks `LocalDeliveryIds` after dispatch completes. If non-null, it resolves `IOutboxRepository` (the non-generic base interface, which already has `MarkAsPublishedAsync`) from the current scope and calls it for each ID.
+
+
+---
+
+## Modified: `IOutboxService<TContext>` / `OutboxEventService`
+
+**Location**: `core/src/Juice.Messaging.Outbox/` (interface) and `core/src/Juice.Messaging.Outbox.EF/` (implementation)
+
+After `SaveEventsAsync`, the service must expose the delivery IDs that were created for the current batch, scoped by publisher key. This allows `MessageService<TContext>` to capture the delivery IDs for `"local"` route entries and pass them into the callback closure.
+
+```
+IOutboxService<TContext>
+├── AddEventAsync(message, cancellationToken)    : ValueTask            (existing)
+├── SaveEventsAsync(transactionId, ct)           : ValueTask            (existing)
+└── GetPendingDeliveryIds(publisherKey)          : IReadOnlyList<Guid>  ← NEW
+```
+
+**Behaviour rules**:
+- `GetPendingDeliveryIds(publisherKey)` returns the delivery IDs created in the most recent `SaveEventsAsync` call for the given `publisherKey`. Returns an empty list if `SaveEventsAsync` has not yet been called or no deliveries were created for that key.
+- The list is cleared on the next `AddEventAsync` call (or reset per save cycle) — it is a transient, per-save snapshot, not a cumulative log.
+- This method is synchronous and allocation-light (returns the IDs already tracked in-memory by `OutboxEventService`).
+
+---
+
+## Modified: `MessageService<TContext>` — local route publish path
+
+**Location**: `core/src/Juice.Messaging/Internal/MessageServiceT.cs`
+
+After `SaveEventsAsync`, for each message with a `"local"` route:
+
+1. Call `_outboxService.GetPendingDeliveryIds("local")` to get the delivery IDs.
+2. Pass those IDs as `LocalDeliveryIds` in the `ChannelEnvelope` when enqueuing to the channel.
+
+No closure, no callback — just data.
+
+**Behaviour rules**:
+- If `GetPendingDeliveryIds("local")` returns empty, pass `null` (or omit the parameter); background service no-ops.
+
+---
+
+## Modified: `LocalChannelBackgroundService` — mark outbox state after dispatch
+
+**Location**: `core/src/Juice.Messaging.Local/Internal/LocalChannelBackgroundService.cs`
+
+After a **successful** dispatch (no exception thrown):
+
+1. Check `envelope.LocalDeliveryIds is { Count: > 0 }`.
+2. If true, resolve `ILocalOutboxDeliveryMarker` from the current scope (`sp.GetService<ILocalOutboxDeliveryMarker>()`).
+3. If the marker is available, call `await marker.MarkPublishedAsync(envelope.LocalDeliveryIds, CancellationToken.None)`.
+4. Wrap in try/catch; log warning on exception — delivery stays `NotPublished` for phase 2 retry.
+
+**Behaviour rules**:
+- `IOutboxRepository` is only resolved and called on success — exceptions in the dispatch path skip the block entirely (the `catch` exits before reaching it), leaving delivery `NotPublished`.
+- `IOutboxRepository` resolves to `null` via `GetService` when no outbox repository is registered (graceful no-op for `"local-channel"`-only setups).
+- The existing metric and error handling paths are unchanged.
+
+---
+
+## Modified: `LocalTransportPublisher` — structured log for phase-1 fallback
+
+**Location**: `core/src/Juice.Messaging.Local/Internal/LocalTransportPublisher.cs`
+
+When `IntegrationEventDispatcher.DispatchAsync` returns `EventDispatchResult.Duplicated` (meaning phase 1 already processed the event but the callback failed to mark it Published):
+
+- Log a structured **warning**: `"Delivery {DeliveryId} for event {EventName} (MessageId={MessageId}) was already processed in phase 1 but its outbox record was not marked — completing now via phase 2."`
+- Increment a dedicated metric counter: `local_delivery_phase1_fallback_total`.
+- Do not throw — return normally so `DeliveryProcessor` marks it `Published` as usual.
+
+**This path is the safety net**: it fires only when the phase 1 callback failed (e.g., DB connection loss between handler success and `MarkAsPublishedAsync`). In normal operation, the delivery record is `Published` before phase 2 scans, and `LocalTransportPublisher` is never called for it.
+
+---
+
+## State Transition Diagram
+
+```
+Phase 1 (happy path):
+  NotPublished ──[SaveEventsAsync]──► NotPublished
+                                          │
+                              [LocalChannelBackgroundService dispatches]
+                                          │
+                              [OnDispatched callback: MarkAsPublishedAsync]
+                                          ▼
+                                       Published ◄── terminal; phase 2 never picks it up
+
+Phase 1 (callback failure / crash):
+  NotPublished ──► ... ──► NotPublished  (phase 2 picks it up)
+                                          │
+                         [DeliveryProcessor: MarkAsInProgressAsync]
+                                          ▼
+                                       InProgress
+                                          │
+                         [LocalTransportPublisher: Duplicated → log warning]
+                                          │
+                         [DeliveryProcessor: MarkAsPublishedAsync]
+                                          ▼
+                                       Published
+
+Phase 1 (handler failure):
+  NotPublished  (callback not invoked / invokes with Failure → no-op)
+       │
+  [DeliveryProcessor: normal retry path]
+       ▼
+  InProgress → Published (or Failed → retry)
+```
+
+---
+
+## No New Libraries
+
+All changes are within existing libraries. No new `core/src/` projects are required. No new EF migrations are needed (no schema changes — `OutboxDelivery` schema is unchanged; only the state value that gets written changes).

--- a/specs/010-local-delivery-skip/plan.md
+++ b/specs/010-local-delivery-skip/plan.md
@@ -1,0 +1,215 @@
+# Implementation Plan: Skip Already-Processed Local Deliveries in Phase 2
+
+**Branch**: `010-local-delivery-skip` | **Date**: 2026-04-14 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `/specs/010-local-delivery-skip/spec.md`
+
+## Summary
+
+When a `"local"` route message is dispatched immediately in phase 1 and all handlers succeed, the outbox delivery record must be marked `Published` before the background delivery processor's next scan. This eliminates the redundant phase-2 cycle (pick up → mark InProgress → call transport → mark Published) for already-completed deliveries, and ensures phase 2 only handles genuine retries and failure recovery.
+
+The implementation extends `ChannelEnvelope` with an optional post-dispatch callback. `MessageService<TContext>` builds that callback — capturing the `"local"` delivery IDs and `IOutboxRepository` factory — and attaches it to the envelope. `LocalChannelBackgroundService` invokes the callback after dispatch completes. If the callback fails (e.g., DB unavailable), the delivery remains `NotPublished` and phase 2 picks it up via its existing safety-net path in `LocalTransportPublisher`.
+
+---
+
+## Technical Context
+
+**Language/Version**: C# on .NET 6 / .NET 8 / .NET 9  
+**Primary Dependencies**: `Juice.Messaging.Local`, `Juice.Messaging`, `Juice.Messaging.Outbox`, `Juice.Messaging.Outbox.EF`  
+**Storage**: EF Core (SQL Server + PostgreSQL) — no schema changes; `OutboxDelivery` record is written with `State = Published` earlier than before  
+**Testing**: xUnit with `[InitializeMessageContext]`, `IgnoreOnCIFact` for EF/RabbitMQ integration tests  
+**Target Platform**: Library (NuGet) — same multi-target as existing: `netstandard2.1`, runnable apps on `net6.0;net8.0;net9.0`  
+**Project Type**: Library  
+**Performance Goals**: Phase 2 performs zero transport calls for phase-1-completed deliveries (measured by `local_delivery_phase1_fallback_total` metric staying at 0 in normal operation)  
+**Constraints**: No breaking changes to `ITransportPublisher`, `IOutboxService<TContext>`, or `ChannelEnvelope` public APIs used by consumers; `LocalChannelBackgroundService` must not depend on EF context type parameters  
+**Scale/Scope**: Affects all `"local"` route deliveries; `"local-channel"`, `"rabbitmq"`, and other publisher keys are unaffected
+
+---
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked post Phase 1 design.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Lightweight & Dual-Architecture | PASS | No new abstractions without concrete use; callback pattern used immediately in `MessageService<TContext>` |
+| II. Library-First Composability | PASS | Changes confined to `Juice.Messaging` and `Juice.Messaging.Local`; no new circular dependencies; no new library projects |
+| III. DDD + CQRS | PASS | Infrastructure concern only; no domain model changes |
+| IV. Reliable Messaging via Outbox Pattern | PASS | Outbox delivery state is now accurate after phase 1; at-least-once delivery preserved via callback-failure fallback |
+| V. Multi-Tenancy First | PASS | No tenant isolation impact |
+
+**Post-design re-check**: All principles pass. No violations.
+
+---
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-local-delivery-skip/
+├── plan.md         ← this file
+├── research.md     ← Phase 0 output
+├── data-model.md   ← Phase 1 output
+└── tasks.md        ← Phase 2 output (/speckit.tasks — not created by /speckit.plan)
+```
+
+### Source Code (affected files)
+
+```text
+core/src/Juice.Messaging/
+└── Internal/
+    └── OutboxEventService.cs           ← expose GetPendingDeliveryIds(publisherKey)
+
+core/src/Juice.Messaging.Local/
+├── ChannelEnvelope.cs                  ← add OnDispatched callback
+├── Internal/
+│   ├── MessageServiceT.cs             ← build & attach callback for "local" routes
+│   ├── LocalChannelBackgroundService.cs ← invoke callback post-dispatch
+│   └── LocalTransportPublisher.cs     ← structured log for Duplicated fallback path
+
+core/test/Juice.Integrations.Tests/
+└── LocalDeliverySkipTest.cs           ← new integration test (IgnoreOnCIFact)
+```
+
+---
+
+## Phase 0: Research
+
+**Status**: Complete. See [research.md](research.md).
+
+### Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| How phase 1 marks deliveries | Post-dispatch callback in `ChannelEnvelope` | Keeps `PublishAsync` non-blocking; avoids `LocalChannelBackgroundService` depending on EF context type |
+| How delivery IDs reach the callback | `IOutboxService<TContext>.GetPendingDeliveryIds(publisherKey)` | In-memory snapshot already populated by `SaveEventsAsync`; no extra DB roundtrip |
+| State for phase-1-completed deliveries | `Published` | Correct terminal state; `Skipped` is for unavailable/obsolete events |
+| Fallback when callback fails | Leave `NotPublished`; phase 2 handles via existing `Duplicated` path | At-least-once delivery preserved; no silent message loss |
+| `Duplicated` result handling in phase 2 | Structured warning log + `local_delivery_phase1_fallback_total` counter | Observability per FR-006; safety-net path distinguishable from normal delivery |
+
+---
+
+## Phase 1: Design & Contracts
+
+**Status**: Complete. See [data-model.md](data-model.md).
+
+### Design Summary
+
+Four targeted changes across two libraries:
+
+#### 1. `ChannelEnvelope` — add `OnDispatched` callback
+
+```csharp
+// Existing
+public record ChannelEnvelope(IMessage Message, MessageContextSnapshot ContextSnapshot);
+
+// New
+public record ChannelEnvelope(
+    IMessage Message,
+    MessageContextSnapshot ContextSnapshot,
+    Func<EventDispatchResult, CancellationToken, ValueTask>? OnDispatched = null);
+```
+
+`OnDispatched` is `null` for `"local-channel"` messages; non-null for `"local"` route messages.
+
+#### 2. `IOutboxService<TContext>` — expose delivery IDs after save
+
+```csharp
+// New method on IOutboxService<TContext>
+IReadOnlyList<Guid> GetPendingDeliveryIds(string publisherKey);
+```
+
+`OutboxEventService` already tracks created deliveries in-memory during `SaveEventsAsync`; this method returns that snapshot by publisher key. No DB roundtrip.
+
+#### 3. `MessageService<TContext>` — build callback for `"local"` routes
+
+After `SaveEventsAsync`, before enqueuing to channel:
+
+```csharp
+var localDeliveryIds = _outboxService.GetPendingDeliveryIds("local");
+Func<EventDispatchResult, CancellationToken, ValueTask>? callback = null;
+
+if (localDeliveryIds.Count > 0)
+{
+    callback = async (result, ct) =>
+    {
+        if (result is EventDispatchResult.Success or EventDispatchResult.Duplicated)
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var repo = scope.ServiceProvider.GetRequiredService<IOutboxRepository<TContext>>();
+            foreach (var id in localDeliveryIds)
+                await repo.MarkAsPublishedAsync(id, ct);
+        }
+    };
+}
+
+// Enqueue with callback
+await _channelWriter.WriteAsync(
+    new ChannelEnvelope(message, contextSnapshot, callback), ct);
+```
+
+#### 4. `LocalChannelBackgroundService` — invoke callback after dispatch
+
+```csharp
+// After DispatchIntegrationEventAsync or MediatR notification dispatch:
+if (envelope.OnDispatched != null)
+{
+    try { await envelope.OnDispatched(result, cancellationToken); }
+    catch (Exception ex)
+    {
+        _logger.LogWarning(ex,
+            "Post-dispatch callback failed for message {MessageId}. " +
+            "Delivery will be retried by background processor.",
+            envelope.Message.MessageId);
+    }
+}
+```
+
+#### 5. `LocalTransportPublisher` — structured log for `Duplicated` fallback
+
+```csharp
+if (result == EventDispatchResult.Duplicated)
+{
+    _logger.LogWarning(
+        "Event {EventName} (MessageId={MessageId}) was already processed in phase 1 " +
+        "but delivery {PublisherKey} was not marked — completing via phase 2 fallback.",
+        integrationEvent.EventName, integrationEvent.MessageId, Key);
+    LocalChannelMetrics.IncrementPhase1Fallback(Key);
+    // Do not throw — DeliveryProcessor marks Published normally.
+}
+```
+
+### No External Contracts
+
+This feature is entirely internal to the framework infrastructure. No public-facing extension method signatures change. No new NuGet packages. No EF migrations needed.
+
+---
+
+## Complexity Tracking
+
+No constitution violations. No complexity justification required.
+
+---
+
+## Testing Strategy
+
+### Unit tests (no infra)
+
+- `ChannelEnvelope` with `OnDispatched` set: verify callback is invoked with correct `EventDispatchResult`.
+- Callback with `Duplicated` result: verify `MarkAsPublishedAsync` is called.
+- Callback with `Failure` result: verify `MarkAsPublishedAsync` is NOT called.
+- Callback exception: verify `LocalChannelBackgroundService` catches it and continues processing next envelope.
+
+### Integration tests (`IgnoreOnCIFact`, requires DB)
+
+- **Happy path**: publish a `"local"` route message, verify handler invoked once, delivery record transitions directly to `Published` without ever entering `InProgress`.
+- **Callback failure simulation**: break the DB after phase 1 dispatch but before callback completes; verify delivery stays `NotPublished`; restore DB; verify phase 2 picks up and marks `Published`.
+- **Phase 2 fallback**: verify `local_delivery_phase1_fallback_total` counter increments when phase 2 encounters a `Duplicated` result (e.g., callback was skipped in test setup).
+- **`"local-channel"` unaffected**: publish a `"local-channel"` route message; verify no callback is attached and no delivery record is written.
+- **`"rabbitmq"` unaffected**: verify existing rabbitmq delivery behaviour is unchanged.
+
+---
+
+## Ready for `/speckit.tasks`
+
+All research resolved, design complete, constitution check passed. The next step is `/speckit.tasks` to break the implementation into ordered, assignable tasks.

--- a/specs/010-local-delivery-skip/research.md
+++ b/specs/010-local-delivery-skip/research.md
@@ -1,0 +1,131 @@
+# Research: Skip Already-Processed Local Deliveries in Phase 2
+
+**Branch**: `010-local-delivery-skip`  
+**Phase**: 0 — Research  
+**Date**: 2026-04-14
+
+---
+
+## Current Two-Phase Flow (as-built)
+
+### Phase 1 — Immediate Dispatch
+
+1. `MessageService<TContext>.PublishAsync` calls `SaveEventsAsync` → creates `OutboxDelivery` records in state `NotPublished`.
+2. For `"local"` routes, calls `PublishLocalMessageAsync(message, true, ...)` → resolves `IMessagePublisher["local-channel"]` → enqueues `ChannelEnvelope` to the in-memory channel. This is fire-and-forget; the result is not captured.
+3. `LocalChannelBackgroundService` drains the channel asynchronously → calls `LocalDispatchHelper.DispatchIntegrationEventAsync` → `IntegrationEventDispatcher.DispatchAsync`.
+4. On success: idempotency key `"{source}:{messageId}"` scoped to `eventName` is recorded as `RequestState.Processed`.
+5. The `OutboxDelivery` record **remains `NotPublished`**. Phase 1 has no access to delivery IDs and does not update them.
+
+### Phase 2 — Background Delivery Processor
+
+1. `DeliveryHostedService` (`SendPendingIntent`) scans for `State = NotPublished` records with `PublisherKey = "local"`.
+2. `DeliveryProcessor.ProcessSingleDeliveryAsync`:
+   - Calls `MarkAsInProgressAsync(deliveryId)` → `State = InProgress`, `ProcessedOn = now`.
+   - Calls `LocalTransportPublisher.PublishAsync` → `IntegrationEventDispatcher.DispatchAsync`.
+   - If phase 1 already succeeded: idempotency check returns `EventDispatchResult.Duplicated`. `LocalTransportPublisher` does not throw (only throws on `Failure`). Returns normally.
+   - Calls `MarkAsPublishedAsync(deliveryId)` → `State = Published`, `ProcessedOn = now`.
+
+### Current behaviour summary
+
+When phase 1 succeeds, phase 2 still runs the full cycle: `NotPublished → InProgress → (Duplicated result, silently ignored) → Published`. Handlers are never invoked twice (idempotency). But the delivery processor still picks up the record, marks it `InProgress`, calls `LocalTransportPublisher`, and marks it `Published`.
+
+---
+
+## Key Findings
+
+### Finding 1 — Phase 1 has no delivery IDs
+
+`OutboxEventService.SaveEventsAsync` creates `OutboxDelivery` objects with generated IDs (`Guid.NewGuid()`), but does not return them. `MessageService<TContext>` only calls `SaveEventsAsync` and then enqueues the message to the channel. The delivery IDs are inaccessible from phase 1 code.
+
+**Decision**: `OutboxEventService` (or the `IOutboxService<TContext>` interface) must expose the created delivery IDs for `"local"` route entries after `SaveEventsAsync`. This is the minimal structural change to enable phase 1 to mark deliveries.
+
+**Alternatives considered**:
+- Query the database for delivery IDs by `EventId` after save — rejected (extra DB roundtrip, race-prone).
+- Carry delivery IDs in `ChannelEnvelope` only (no service interface change) — rejected because the IDs are not available until after `SaveEventsAsync`, which runs before the enqueue.
+
+---
+
+### Finding 2 — Channel dispatch is fire-and-forget; result unknown at enqueue time
+
+`LocalChannelBackgroundService` dispatches asynchronously from the channel. At the moment `MessageService<TContext>.PublishAsync` returns, the handler has only been enqueued — not yet executed. This means the caller cannot synchronously know if phase 1 succeeded.
+
+**Decision**: `LocalChannelBackgroundService` must invoke a post-dispatch callback after successful dispatch. The callback captures `MarkAsPublishedAsync` via closure registered by `MessageService<TContext>` at enqueue time. This keeps `PublishAsync` non-blocking and avoids `LocalChannelBackgroundService` taking a dependency on `IOutboxRepository<TContext>` (which requires the context type parameter it doesn't know).
+
+**Alternatives considered**:
+- Direct synchronous dispatch in `MessageService<TContext>` for `"local"` routes (await handlers inline, then mark Published) — viable but changes `PublishAsync` to block on handler completion, which may be surprising to callers and increases latency.
+- `LocalChannelBackgroundService` takes `IOutboxRepository` and delivery IDs in the envelope — rejected because `LocalChannelBackgroundService` is a generic singleton that should not depend on EF context types.
+- Check idempotency store in `DeliveryProcessor` before calling `LocalTransportPublisher` — rejected because it adds a cross-component coupling (delivery processor querying idempotency store), and still doesn't mark the record in a terminal state before the scan (violates FR-001/FR-005).
+
+---
+
+### Finding 3 — `EventDispatchResult.Duplicated` exists but is invisible to the delivery processor
+
+`IntegrationEventDispatcher.DispatchAsync` returns `EventDispatchResult.Duplicated` when idempotency detects the event was already processed. `LocalTransportPublisher.PublishAsync` currently only throws on `Failure`; `Duplicated` is silently treated the same as `Success`. The delivery processor receives no signal about the duplication.
+
+**Decision**: When phase 1 successfully marks the delivery as `Published` (via the callback mechanism), phase 2 will never pick up the record (it queries only `NotPublished`). The `Duplicated` path in `LocalTransportPublisher` becomes a fallback for edge cases (callback failed, crash between phase 1 dispatch and the mark). In that fallback, `LocalTransportPublisher` should log a structured warning: "Delivery {DeliveryId} was already processed by phase 1 immediate dispatch — marking Published".
+
+---
+
+### Finding 4 — `MarkAsInProgressAsync` is a concurrency guard
+
+`OutboxRepository.MarkAsInProgressAsync` uses an `ExecuteUpdateAsync` with `WHERE State IN (NotPublished, Failed)` and returns affected row count. If 0, another worker already claimed it. This guard already prevents race conditions between multiple delivery processor instances. After our change, `Published` records are never fetched by the `SendPendingIntent` query (`WHERE State = NotPublished`), so the race scenario for phase-1-completed deliveries disappears entirely.
+
+---
+
+### Finding 5 — Delivery state for "already processed" case
+
+When phase 1 marks the delivery `Published` and phase 2 never picks it up, `ProcessedOn` reflects phase 1's timestamp — which is earlier than the delivery processor's scan. This is correct: `ProcessedOn` means "when the delivery was completed", regardless of which phase completed it.
+
+---
+
+### Finding 6 — `DeliveryState.Skipped` exists
+
+`OutboxDelivery` has a `Skipped` state (value 4) intended for "event is no longer relevant, destination unavailable." This is NOT the right state for phase-1-processed deliveries — those were successfully delivered and should be `Published`. Using `Skipped` would misrepresent the delivery outcome.
+
+**Decision**: Use `Published` (not `Skipped`) when phase 1 completes the delivery. Reserve `Skipped` for its existing semantics (unavailable destination or obsolete event).
+
+---
+
+## Architecture Decision: Delivery Completion Callback
+
+The design that satisfies all requirements without coupling `LocalChannelBackgroundService` to EF context types:
+
+1. **`ChannelEnvelope`** — extended to carry an optional `Func<EventDispatchResult, CancellationToken, ValueTask>? OnDispatched` callback.
+2. **`MessageService<TContext>`** — for `"local"` routes, creates the callback closure capturing `deliveryIds` and the scoped `IOutboxRepository<TContext>`. Passes it in the `ChannelEnvelope`.
+3. **`LocalChannelBackgroundService`** — after `IntegrationEventDispatcher.DispatchAsync`, invokes `OnDispatched(result, ct)` if present. Does not interpret the result itself.
+4. **`MessageService<TContext>` callback body**:
+   - `Success` → `MarkAsPublishedAsync(deliveryId)` for each delivery ID
+   - `Failure` / `NotHandled` → leave as `NotPublished` (phase 2 will retry or handle)
+   - `Duplicated` → treated as success (idempotency says it was processed); call `MarkAsPublishedAsync`
+
+This design:
+- Keeps `LocalChannelBackgroundService` generic (no context type dependency)
+- Keeps `PublishAsync` non-blocking (callback runs inside the background service's processing loop)
+- Satisfies FR-001 (delivery marked terminal before phase 2's next scan)
+- Satisfies FR-005 (skip decision in phase 2 is purely state-based)
+- Does not affect `"local-channel"` route (no callback set → no-op)
+- Does not affect non-`"local"` publisher keys in phase 2
+
+---
+
+## Libraries affected
+
+| Library | Change |
+|---|---|
+| `Juice.Messaging.Local` | `ChannelEnvelope`: add optional `OnDispatched` callback; `LocalChannelBackgroundService`: invoke callback post-dispatch |
+| `Juice.Messaging` | `IOutboxService<TContext>` (or `OutboxEventService`): expose delivery IDs for "local" routes after save |
+| `Juice.Messaging.Local` | `MessageService<TContext>`: build and attach the callback for "local" routes |
+| `Juice.Messaging.Local` | `LocalTransportPublisher`: add structured log when `Duplicated` (fallback path) |
+| No new libraries required | All changes are within existing layer boundaries |
+
+---
+
+## Constitution Compliance
+
+| Principle | Impact |
+|---|---|
+| I. Lightweight & Dual-Architecture | No new abstractions without concrete use; callback is used immediately |
+| II. Library-First Composability | No new circular dependencies; changes stay within `Juice.Messaging` and `Juice.Messaging.Local` |
+| III. DDD + CQRS | Not directly applicable (infrastructure concern) |
+| IV. Reliable Messaging via Outbox Pattern | Strengthened — outbox delivery state is now accurate after phase 1 |
+| V. Multi-Tenancy First | No impact |

--- a/specs/010-local-delivery-skip/spec.md
+++ b/specs/010-local-delivery-skip/spec.md
@@ -1,0 +1,110 @@
+# Feature Specification: Skip Already-Processed Local Deliveries in Phase 2
+
+**Feature Branch**: `010-local-delivery-skip`  
+**Created**: 2026-04-14  
+**Status**: Draft  
+**Input**: User description: "The outbox delivery for local must be skipped in delivery processor if it is already processed in pharse 1"
+
+## Background
+
+The `"local"` route delivers messages in two phases:
+
+- **Phase 1** — Immediate dispatch: right after the outbox record is committed to the database, the message is also dispatched in-process to handlers. If all handlers succeed, an idempotency key is recorded.
+- **Phase 2** — Background delivery: the `DeliveryHostedService` later picks up the `NotPublished` outbox record, calls `LocalTransportPublisher`, which checks idempotency and skips handler invocation if phase 1 already ran.
+
+Currently, phase 2 always runs through the full transport dispatch cycle even when phase 1 already succeeded. The handler is skipped via idempotency, but the delivery processor still pays the overhead of picking up the record, marking it `InProgress`, calling the transport, and marking it `Published`. The goal is to eliminate this redundant work by allowing the system to recognize phase-1-completed records and close them out without invoking the transport at all.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Phase 1 success closes the delivery record (Priority: P1)
+
+When a `"local"` route message is successfully dispatched during phase 1 (immediately after outbox commit), the outbox delivery record is marked as completed so the background delivery processor does not need to re-dispatch it.
+
+**Why this priority**: This is the core of the feature — without it, every `"local"` delivery causes unnecessary background work. It also prevents the idempotency store from being queried on every delivery cycle for records that are already done.
+
+**Independent Test**: Can be tested end-to-end by publishing a `"local"` route message, verifying phase 1 dispatch ran (handler invoked, result logged), and then confirming the delivery record never transitions through `InProgress` in the background delivery processor.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `"local"` route message is published and phase 1 dispatches all handlers successfully, **When** the background delivery processor scans for pending records, **Then** the record is not picked up for re-dispatch because it is already in a terminal state.
+2. **Given** a `"local"` route outbox record in a terminal state, **When** the delivery processor encounters it during a scan, **Then** it is skipped without calling `LocalTransportPublisher` and without any handler invocation.
+3. **Given** phase 1 succeeds for a `"local"` message, **When** the application is inspected after delivery, **Then** the delivery record shows a completed state with a recorded processing time that reflects the phase 1 completion, not a later background processing time.
+
+---
+
+### User Story 2 — Phase 1 failure falls back to normal background delivery (Priority: P1)
+
+When phase 1 dispatch fails or is skipped (e.g., channel is full, handler throws, process restarted before phase 1 ran), the background delivery processor picks up the record and invokes handlers exactly as it does today.
+
+**Why this priority**: Correctness — no message must be silently dropped. Phase 2 is the durability guarantee; weakening it for the failure path would break the reliability contract of the `"local"` route.
+
+**Independent Test**: Can be tested by simulating a phase 1 failure (e.g., a throwing handler or a process restart mid-publish) and verifying the background delivery processor picks up the record and invokes handlers.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `"local"` route message is published but phase 1 dispatch throws an exception, **When** the background delivery processor runs, **Then** it picks up the `NotPublished` record and invokes handlers normally.
+2. **Given** a process crash between outbox commit and phase 1 dispatch, **When** the process restarts and the delivery processor runs, **Then** the `NotPublished` record is picked up and handlers are invoked exactly once.
+3. **Given** phase 1 dispatch returns a partial failure result (some handlers fail), **When** the background delivery processor evaluates the record, **Then** it treats the record as not yet completed and processes it via the normal delivery path.
+
+---
+
+### User Story 3 — Observability: skipped deliveries are distinguishable from processed ones (Priority: P2)
+
+When the delivery processor skips a `"local"` record because it was completed in phase 1, this action is visible in logs and/or metrics so operators can distinguish between "processed by delivery worker" and "completed by immediate dispatch".
+
+**Why this priority**: Without visibility, diagnosing delivery pipeline issues is difficult. Operators need to be able to confirm that skipped records were intentionally skipped, not silently lost.
+
+**Independent Test**: Can be tested by checking that a structured log entry or counter is emitted when a delivery is skipped due to phase 1 completion.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `"local"` delivery record completed in phase 1, **When** the delivery processor encounters it, **Then** a log entry or metric increment records that the record was skipped as already processed.
+2. **Given** normal delivery (phase 1 did not complete), **When** the delivery processor processes the record, **Then** the log/metric shows a regular delivery, not a skip.
+
+---
+
+### Edge Cases
+
+- What happens when a `"local"` handler throws after phase 1 has already marked part of the idempotency state? The record must not be left in an ambiguous state — either phase 1 did not complete (record stays `NotPublished`, phase 2 retries) or phase 1 completed all handlers (record is closed, phase 2 skips).
+- What happens if the process crashes between phase 1 completing and the delivery record being updated to the terminal state? The record remains `NotPublished`; the delivery processor must pick it up and re-attempt. The idempotency service prevents double handler invocation in this case.
+- What happens when two delivery processor instances (horizontal scaling) both see the same `NotPublished` record before phase 1 closes it? Standard optimistic-locking / state-transition guards must prevent both from processing it.
+- What happens when the idempotency store is unavailable? The system must default to running the delivery (safe fallback) rather than skipping it, to avoid silent message loss.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When all handlers for a `"local"` route message complete successfully during phase 1 dispatch, the system MUST update the corresponding outbox delivery record to a terminal state before the background delivery processor's next scan.
+- **FR-002**: The background delivery processor MUST NOT invoke `LocalTransportPublisher` for a `"local"` delivery record that is already in a terminal state.
+- **FR-003**: When phase 1 dispatch fails (exception, partial failure, or skipped), the system MUST leave the delivery record in `NotPublished` state so the background delivery processor picks it up.
+- **FR-004**: When a process restart occurs between outbox commit and phase 1 dispatch, the delivery processor MUST pick up the `NotPublished` record and dispatch it through the normal background delivery path.
+- **FR-005**: The skip decision in the delivery processor MUST be based solely on the delivery record's persisted state — no in-memory flag, no cross-process shared cache required for correctness.
+- **FR-006**: When the delivery processor skips a record, it MUST emit a structured log entry or increment a metric counter that is distinguishable from a normal delivery completion.
+- **FR-007**: The feature MUST NOT affect delivery behavior for non-`"local"` publisher keys (e.g., `"rabbitmq"`).
+
+### Key Entities
+
+- **Outbox Delivery Record**: Tracks the delivery state of one outbox event for one publisher key. States: `NotPublished` → `InProgress` → `Published` (terminal) or `Failed`. Phase 1 targets this record to set its state to `Published` on success.
+- **Phase 1 Dispatch**: The in-process dispatch that occurs immediately after outbox commit. Produces a success or failure result that determines whether the delivery record is closed.
+- **Delivery Processor**: Background service that scans for `NotPublished` records. Must respect the terminal state written by phase 1 and skip those records.
+
+---
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For `"local"` route messages where phase 1 dispatch succeeds, the background delivery processor performs zero handler invocations for those records — confirmed by zero `LocalTransportPublisher.PublishAsync` calls for phase-1-completed records.
+- **SC-002**: For `"local"` route messages where phase 1 fails, 100% of records are eventually delivered by the background delivery processor (no silent drops).
+- **SC-003**: A process crash between outbox commit and phase 1 dispatch results in handlers being invoked exactly once by the delivery processor on restart — no double invocations, no skips.
+- **SC-004**: Every delivery record skip due to phase 1 completion is individually traceable in logs or metrics, with zero ambiguous cases (a record is either "skipped as phase-1-complete" or "delivered by background processor").
+
+### Assumptions
+
+- The idempotency service is registered when the `"local"` route is in use. If it is absent, phase 2 retains its current behavior (handler invoked again, idempotency dedup not available).
+- Closing the delivery record in phase 1 rather than doing a pre-check in phase 2 is the preferred approach — it reduces delivery processor load and avoids any per-record lookup in phase 2.
+- "Phase 1 success" is defined as all handlers completing without exception. Partial failure (any handler throws) counts as phase 1 failure, leaving the record for phase 2.

--- a/specs/010-local-delivery-skip/tasks.md
+++ b/specs/010-local-delivery-skip/tasks.md
@@ -1,0 +1,161 @@
+# Tasks: Skip Already-Processed Local Deliveries in Phase 2
+
+**Input**: Design documents from `/specs/010-local-delivery-skip/`  
+**Branch**: `010-local-delivery-skip`  
+**Tests**: Integration tests included in Polish phase (not TDD; implementation first).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: User story this task belongs to ([US1], [US2], [US3])
+
+---
+
+## Phase 1: Setup
+
+No new projects or packages required. All changes are within existing libraries. Skip directly to Foundational.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Interface and data model changes that all story tasks depend on. Must complete before Phase 3.
+
+**⚠️ CRITICAL**: All user story tasks depend on T001–T003.
+
+- [X] T001 Extend `ChannelEnvelope` record with an optional `IReadOnlyList<Guid>? LocalDeliveryIds = null` parameter (null for "local-channel" messages, populated with outbox delivery IDs for "local" route messages) in `core/src/Juice.Messaging.Local/Internal/ChannelEnvelope.cs`
+
+- [X] T002 Add `IReadOnlyList<Guid> GetPendingDeliveryIds(string publisherKey)` method to `IOutboxService` interface in `core/src/Juice.Messaging/Outbox/IOutboxService.cs`
+
+- [X] T003 Implement `GetPendingDeliveryIds` in `OutboxEventService`: track created `OutboxDelivery` IDs per publisher key during `SaveEventsAsync` in an internal `Dictionary<string, List<Guid>>` field (cleared at the start of each `SaveEventsAsync`), and return the matching list in `GetPendingDeliveryIds` in `core/src/Juice.Messaging.Outbox/Internal/OutboxEventService.cs`
+
+**Checkpoint**: `ChannelEnvelope` carries delivery IDs as data; `IOutboxRepository` (non-generic, already has `MarkAsPublishedAsync`) is resolvable directly. Story tasks can now begin.
+
+---
+
+## Phase 3: User Story 1 — Phase 1 Success Closes Delivery Record (Priority: P1) 🎯 MVP
+
+**Goal**: When all handlers succeed during phase 1 immediate dispatch, the outbox delivery record is marked `Published` — the background delivery processor never picks it up.
+
+**Independent Test**: Publish a `"local"` route message with a succeeding handler. Verify the `OutboxDelivery` record transitions directly from `NotPublished` to `Published` without ever entering `InProgress`. Confirm the background delivery processor emits no InProgress log for that delivery.
+
+- [X] T007 [US1] In `MessageService<TContext>` (in the code path that calls `SaveEventsAsync` then enqueues for `"local"` routes): after `SaveEventsAsync`, call `_outboxService.GetPendingDeliveryIds("local")`; pass the result as `LocalDeliveryIds` in the `ChannelEnvelope` constructor when calling `PublishLocalMessageAsync` (or equivalent). If the list is empty, pass `null`. No closure, no callback — data only. In `core/src/Juice.Messaging/Internal/MessageServiceT.cs`
+
+- [X] T008 [US1] In `LocalChannelBackgroundService`, after the dispatch succeeds (inside the `try` block, after both `IIntegrationEvent` and `INotification` dispatch paths, before the metrics calls): check `envelope.LocalDeliveryIds is { Count: > 0 }`; if true, resolve `sp.GetService<IOutboxRepository>()`; if non-null, call `await repo.MarkAsPublishedAsync(id, CancellationToken.None)` for each ID inside a nested try/catch that logs `LogWarning` "Failed to mark local delivery Published for message {MessageId} — delivery will be retried by background processor" on exception. In `core/src/Juice.Messaging.Local/Internal/LocalChannelBackgroundService.cs`
+
+**Checkpoint**: Publish a `"local"` message → handler runs → delivery goes directly to `Published`. Background processor sees no `NotPublished` records. User Story 1 independently testable.
+
+---
+
+## Phase 4: User Story 2 — Phase 1 Failure Falls Back to Phase 2 (Priority: P1)
+
+**Goal**: When phase 1 dispatch fails (handler throws, `NotHandled`, or callback exception), the outbox delivery record stays `NotPublished` and the background delivery processor picks it up and retries normally.
+
+**Independent Test**: Register a throwing handler for a `"local"` route message. Publish the message. Verify the delivery stays `NotPublished`. Confirm the delivery processor picks it up, marks `InProgress`, calls the handler again, and marks `Published` (or `Failed` if the handler still throws).
+
+- [X] T009 [US2] Add a code comment above the `MarkPublishedAsync` call inside `LocalChannelBackgroundService` (T008) explaining the failure invariant: "If the marker throws (e.g. DB unavailable), the exception is caught and logged here. The delivery record remains NotPublished — the background delivery processor will pick it up and retry. No message is lost." in `core/src/Juice.Messaging.Local/Internal/LocalChannelBackgroundService.cs`
+
+- [X] T010 [US2] Add a code comment above `ProcessSingleDeliveryAsync` in `DeliveryProcessor` explaining the phase-1 relationship: "For 'local' publisher: if phase 1 succeeded and LocalChannelBackgroundService marked the record Published, SendPendingIntent never retrieves it (filters to NotPublished only). This path handles phase 1 failures and crash-recovery scenarios." in `core/src/Juice.Messaging.Outbox.Delivery/Processing/DeliveryProcessor.cs`
+
+**Checkpoint**: Force a handler failure → delivery stays `NotPublished` → delivery processor picks it up. User Story 2 independently testable.
+
+---
+
+## Phase 5: User Story 3 — Observability: Phase-1 Fallback Distinguishable (Priority: P2)
+
+**Goal**: When the background delivery processor encounters a `"local"` delivery that was already processed by phase 1 (idempotency returns `Duplicated`), it emits a structured warning log and increments a dedicated metric counter — distinguishable from normal delivery completions.
+
+**Independent Test**: Disable the `OnDispatched` callback in a test (or simulate a callback failure). Publish a `"local"` message, let phase 1 dispatch run without marking Published. Let phase 2 process the delivery. Confirm a `LogWarning` entry with "already processed in phase 1" is present and that `local_delivery_phase1_fallback_total` counter increments.
+
+- [X] T011 [US3] Add a `static void IncrementPhase1Fallback(string publisherKey)` method to `LocalChannelMetrics` that increments a counter named `"local_delivery_phase1_fallback_total"` tagged with `publisher = publisherKey`, following the same pattern as existing `IncrementDeliverySuccess` in `core/src/Juice.Messaging.Local/Internal/LocalChannelMetrics.cs`
+
+- [X] T012 [P] [US3] In `LocalTransportPublisher.PublishAsync`, after `LocalDispatchHelper.DispatchIntegrationEventAsync` returns `EventDispatchResult.Duplicated`: add `_logger.LogWarning("Event {EventName} (MessageId={MessageId}) was already processed in phase 1 immediate dispatch but its delivery record was not marked Published — completing via phase 2 fallback. PublisherKey={PublisherKey}.", integrationEvent.EventName, integrationEvent.MessageId, Key)` and call `LocalChannelMetrics.IncrementPhase1Fallback(Key)`. Do not throw — return normally so `DeliveryProcessor` marks the record `Published`. In `core/src/Juice.Messaging.Local/Internal/LocalTransportPublisher.cs`
+
+**Checkpoint**: Force phase-2 fallback path → warning log appears → counter increments. User Story 3 independently testable.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T013 [P] Add XML doc comment to `ChannelEnvelope.LocalDeliveryIds` explaining: "Outbox delivery IDs for `'local'` route messages. When non-null, `LocalChannelBackgroundService` calls `ILocalOutboxDeliveryMarker.MarkPublishedAsync` after a successful dispatch. Null for `'local-channel'` messages (no outbox backing)." in `core/src/Juice.Messaging.Local/Internal/ChannelEnvelope.cs`
+
+- [X] T014 [P] Add XML doc comment to `IOutboxService.GetPendingDeliveryIds` explaining: "Returns the delivery IDs created for the given `publisherKey` during the most recent `SaveEventsAsync` call. Returns an empty list if no deliveries were created for that key. This snapshot is cleared at the start of each new `SaveEventsAsync` cycle." in `core/src/Juice.Messaging/Outbox/IOutboxService.cs`
+
+- [X] T015 Integration test — US1 happy path: publish a `"local"` route `IIntegrationEvent` with a succeeding handler, then assert: (a) handler invoked exactly once, (b) `OutboxDelivery.State == Published` without any background delivery processor cycle. Use `IgnoreOnCIFact` and `[InitializeMessageContext]`. Add to `core/test/Juice.Messaging.Local.Tests/LocalDeliverySkipTests.cs`
+
+- [X] T016 [P] Integration test — US2 failure fallback: register a throwing handler for a `"local"` route message, publish it, assert `State == NotPublished` after publish. Let the delivery processor run and assert delivery eventually reaches `Published` or `Failed`. Use `IgnoreOnCIFact`. Add to `core/test/Juice.Messaging.Local.Tests/LocalDeliverySkipTests.cs`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Foundational (Phase 2)**: No dependencies — start immediately. **BLOCKS all story phases.**
+  - T001–T003 can be done in parallel (different files).
+- **US1 (Phase 3)**: Requires T001–T003 complete. T007 and T008 can be done in parallel (different files).
+- **US2 (Phase 4)**: Requires T007–T008 complete. T009–T010 are comment-only, parallel.
+- **US3 (Phase 5)**: Independent of US1/US2. T011 and T012 can be done in parallel.
+- **Polish (Phase 6)**: T013–T014 independent of each other. T015–T016 require all story phases complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: After Foundational — no dependency on US2 or US3.
+- **US2 (P1)**: After US1 — verifies failure invariants in files already modified.
+- **US3 (P2)**: After Foundational (T001) — independent of US1/US2.
+
+### Parallel Opportunities
+
+- T004 and T005 (Foundational) — different files, parallel.
+- T007 and T008 (US1) — different files, parallel.
+- T009 and T010 (US2) — different files, parallel.
+- T011 and T012 (US3) — different files, parallel.
+- T013 and T014 (Polish docs) — different files, parallel.
+- T015 and T016 (Polish tests) — same test file; sequential or separate test classes.
+
+---
+
+## Parallel Example: Foundational → US1
+
+```
+Parallel: T001 (ChannelEnvelope — add LocalDeliveryIds)
+          T002 (IOutboxService interface — add GetPendingDeliveryIds)
+          T003 (OutboxEventService impl — track and expose delivery IDs)
+
+After T001 + T002 + T003:
+  Parallel: T007 (MessageServiceT.cs — populate LocalDeliveryIds in envelope)
+            T008 (LocalChannelBackgroundService — resolve IOutboxRepository and call MarkAsPublishedAsync)
+
+US3 (independent — needs no Foundational tasks):
+  Parallel: T011 (LocalChannelMetrics — add phase1 fallback counter)
+            T012 (LocalTransportPublisher — log + counter on Duplicated)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 2: Foundational (T001–T003)
+2. Complete Phase 3: US1 (T007–T008)
+3. **STOP and VALIDATE**: Confirm `"local"` deliveries go directly to `Published` without delivery processor involvement.
+4. Polish T013–T014 (docs) — optional before shipping MVP.
+
+### Incremental Delivery
+
+1. **Foundational** → foundation ready (T001–T003)
+2. **US1** → core happy path (T004–T005) → delivery processor no longer re-processes phase-1-complete records
+3. **US2** → failure path verified/documented (T006–T007) → at-least-once delivery confirmed correct
+4. **US3** → observability (T008–T009) → operators can distinguish fallback from normal delivery
+5. **Polish** → tests + docs (T010–T013)
+
+---
+
+## Notes
+
+- **No breaking changes**: `ChannelEnvelope` gains an optional parameter (default `null`) — existing call sites unaffected. No closures or callbacks in the envelope — data only.
+- **No schema changes**: `OutboxDelivery` schema unchanged; only which phase writes `Published` changes.
+- **`"local-channel"` unaffected**: No `OnDispatched` callback is set → background service no-ops on the null check.
+- **`"rabbitmq"` unaffected**: Delivery processor path for non-`"local"` keys is unchanged.
+- **Crash safety**: If process crashes after phase 1 dispatch but before callback fires, delivery stays `NotPublished`. Phase 2 picks it up. `IntegrationEventDispatcher` idempotency prevents double invocation → `Duplicated` result → US3 fallback log fires → delivery marked `Published`. No message lost.

--- a/test/Juice.Tests.Host/Juice.Tests.Host.csproj
+++ b/test/Juice.Tests.Host/Juice.Tests.Host.csproj
@@ -27,6 +27,8 @@
         <ProjectReference Include="..\..\core\src\Juice.Messaging.Idempotency.EF.PostgreSQL\Juice.Messaging.Idempotency.EF.PostgreSQL.csproj" />
         <ProjectReference Include="..\..\core\src\Juice.Messaging.Idempotency.EF.SqlServer\Juice.Messaging.Idempotency.EF.SqlServer.csproj" />
         <ProjectReference Include="..\..\core\src\Juice.Messaging.Idempotency.EF\Juice.Messaging.Idempotency.EF.csproj" />
+        <ProjectReference Include="..\..\core\src\Juice.Messaging.Local\Juice.Messaging.Local.csproj" />
+        <ProjectReference Include="..\..\core\src\Juice.Messaging.Outbox.Delivery\Juice.Messaging.Outbox.Delivery.csproj" />
         <ProjectReference Include="..\..\core\src\Juice.Messaging.Outbox.Migrations.PostgreSQL\Juice.Messaging.Outbox.Migrations.PostgreSQL.csproj" />
         <ProjectReference Include="..\..\core\src\Juice.Messaging.Outbox.Migrations.SqlServer\Juice.Messaging.Outbox.Migrations.SqlServer.csproj" />
         <ProjectReference Include="..\..\core\test\Juice.EF.Tests.PostgreSQL\Juice.EF.Tests.PostgreSQL.csproj" />

--- a/test/Juice.Tests.Host/Program.cs
+++ b/test/Juice.Tests.Host/Program.cs
@@ -1,7 +1,6 @@
 ﻿using Juice;
 using Juice.EF.Tests.Infrastructure;
 using Juice.Messaging;
-using Juice.Modular;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Caching.Distributed;
 
@@ -19,6 +18,24 @@ builder.Services.AddOutboxMigrations<TestContext>(configuration, options=> {
     options.DatabaseProvider = provider;
     options.ConnectionName = provider == "PostgreSQL" ? "PostgreConnection" : "SqlServerConnection";
 });
+
+builder.Services.AddMediatR();
+
+builder.Services.AddMessaging()
+    .AddOutbox()
+    .AddDelivery(delivery => {
+        delivery.AddDeliveryPolicies(_ => { });
+        delivery.AddDeliveryProcessor<TestContext>("rabbitmq");
+        delivery.AddDeliveryProcessor<TestContext>("local");
+    })
+    .AddLocalPublisher()
+    .AddEventBus()
+    .AddRabbitMQ(cfg =>
+    {
+        cfg.AddConnection("rabbitmq", configuration.GetSection("Juice:EventBus:Connections:RabbitMQ"));
+        cfg.AddProducer("rabbitmq", "rabbitmq");
+    })
+    ;
 
 builder.AddDiscoveredModules();
 


### PR DESCRIPTION
… succeeds

- OutboxEventService tracks delivery IDs per (messageId, publisherKey) during SaveEventsAsync; exposed via IOutboxService<TContext>.GetPendingDeliveryIds
- MessageService<TContext> retrieves "local" delivery IDs after save and passes them through IMessagePublisher overload → ChannelEnvelope.LocalDeliveryIds
- LocalChannelBackgroundService marks deliveries Published via IOutboxRepository after successful dispatch; skips marking on handler failure (Failure result)
- LocalTransportPublisher logs warning + increments phase1_fallback_total metric when idempotency detects a duplicate (phase-1 did not close the record)
- DeliveryBuilder: fix AddDeliveryProcessor using Add() instead of AddHostedService() to bypass TryAddEnumerable deduplication for same-type hosted services
- Add LocalMessagingBuilderExtensions XML doc for AddLocalPublisher
- Add LocalDeliverySkipTests covering US1 (success marks Published) and US2 (failure leaves NotPublished)